### PR TITLE
fix: correct cursor plugin name

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "Slack",
+  "name": "slack",
   "description": "Slack MCP server. Search channels, send messages, and perform other Slack actions through MCP-compatible clients.",
   "mcpServers": "../.cursor-mcp.json",
   "author": {


### PR DESCRIPTION
Updates the casing on the name for the Cursor Slack plugin so it clears validation on the cursor dashboard.