### PR TITLE
chore: add explicit version to cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "slack",
   "description": "Slack MCP server. Search channels, send messages, and perform other Slack actions through MCP-compatible clients.",
+  "version": "1.0.0",
   "mcpServers": "../.cursor-mcp.json",
   "author": {
     "name": "Slack"


### PR DESCRIPTION
## What & why

Adds an explicit `"version": "1.0.0"` to `.cursor-plugin/plugin.json`.

This is a standalone, minimal change split out of #50 so that PR can stay scoped to just the new skills. It establishes a version baseline for the Cursor plugin.

## Background

Cursor's [plugin docs](https://cursor.com/docs/plugins) don't document version-based update gating, the update path they describe is marketplace Auto Refresh, which fires *"whenever changes are pushed"* (commit-driven, not version-driven). Without a `version` field, we have no deliberate release lever: changes go live as soon as they hit `main`.

Setting a baseline here gives us that lever and matches:
- The existing `version: "1.0.0"` in `.claude-plugin/plugin.json`
- The `maintainers_guide.md` convention that every release bumps **both** manifests following semver

## Release sequence this unblocks

1. **This PR** establish the `1.0.0` baseline (no user-facing change)
2. Land the skills PR (#50) behind the baseline
3. Bump both manifests to `1.1.0` to cut the real release once follow-ups are in

Context: https://github.com/slackapi/slack-mcp-plugin/pull/50#discussion_r3425203459

🤖 Generated with [Claude Code](https://claude.com/claude-code)