### PR TITLE
chore: release v1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slack",
   "description": "Slack integration for searching messages, sending communications, managing canvases, and more",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
   "name": "Slack",
   "url": "https://slack.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slack",
   "description": "Slack MCP server. Search channels, send messages, and perform other Slack actions through MCP-compatible clients.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "mcpServers": "../.cursor-mcp.json",
   "author": {
     "name": "Slack"


### PR DESCRIPTION
## Summary

Bump the plugin version from `1.0.0` to `1.1.0` in preparation for the 1.1.0 release.

- Bumped `.claude-plugin/plugin.json` → `1.1.0`
- Bumped `.cursor-plugin/plugin.json` → `1.1.0`

## Release notes

This release packages the changes added since 1.0.0 (developer skills, test suite, and project tooling — see #50).

## Follow-ups after merge

- [ ] Tag `v1.1.0` on `main`
- [ ] GitHub Release `v1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)