### PR TITLE
feat: add `make cursor` for local Cursor plugin testing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Slack integration for searching messages, sending communications, managing canvases, and more",
   "version": "1.0.0",
   "author": {
-  "name": "Slack",
-  "url": "https://slack.com"
+    "name": "Slack",
+    "url": "https://slack.com"
   },
   "homepage": "https://github.com/slackapi/slack-mcp-cursor-plugin",
   "license": "MIT"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -5,5 +5,6 @@
   "mcpServers": "../.cursor-mcp.json",
   "author": {
     "name": "Slack"
-  }
+  },
+  "skills": "./skills/"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Requires Python 3.14+. Run `make install` before first use to set up the virtual
 | `make test-eval` | LLM-judged tests (starts Ollama, runs DeepEval, stops Ollama) |
 | `make test` | Both unit + eval tests |
 | `make clean` | Remove .venv and .ollama |
+| `make cursor sync` | Install this plugin into a local Cursor for development |
+| `make cursor wipe` | Remove this plugin from the local Cursor install |
 
 The LLM tests read two environment variables: `OLLAMA_MODEL_NAME` (the DeepEval judge model, defaults to `gemma4`) and `SLACK_MCP_TOKEN` (a Slack MCP bearer token; the MCP tool-selection test is skipped when it's unset). Copy `.env.example` to `.env` and fill in values — the `Makefile` auto-loads `.env` — or pass them inline, e.g. `OLLAMA_MODEL_NAME=<model> make test-eval`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Requires Python 3.14+. Run `make install` before first use to set up the virtual
 | `make test-eval` | LLM-judged tests (starts Ollama, runs DeepEval, stops Ollama) |
 | `make test` | Both unit + eval tests |
 | `make clean` | Remove .venv and .ollama |
-| `make cursor sync` | Install this plugin into a local Cursor for development |
-| `make cursor wipe` | Remove this plugin from the local Cursor install |
+| `make cursor-install` | Install this plugin into a local Cursor for development |
+| `make cursor-uninstall` | Uninstall this plugin from the local Cursor install |
 
 The LLM tests read two environment variables: `OLLAMA_MODEL_NAME` (the DeepEval judge model, defaults to `gemma4`) and `SLACK_MCP_TOKEN` (a Slack MCP bearer token; the MCP tool-selection test is skipped when it's unset). Copy `.env.example` to `.env` and fill in values — the `Makefile` auto-loads `.env` — or pass them inline, e.g. `OLLAMA_MODEL_NAME=<model> make test-eval`.
 

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,7 @@ OLLAMA_MODEL := $(or $(OLLAMA_MODEL_NAME),gemma4)
 
 UNAME_S := $(shell uname -s)
 
-TARGETS := help install install-test install-tools clean lint format test test-unit test-eval cursor
-# Positional: the first goal is the command (the target), everything after it is
-# arguments forwarded to that target's recipe. Unlike a $(filter-out)-based
-# approach this passes through words that happen to match a target name (e.g.
-# `make cursor wipe`), since only the leading goal is treated as the command.
-ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+TARGETS := help install install-test install-tools clean lint format test test-unit test-eval cursor-install cursor-uninstall
 
 .PHONY: $(TARGETS)
 
@@ -69,11 +64,14 @@ install-tools: $(VENV) ## Install linting/formatting tools (ruff)
 	$(PIP) install -e ".[tools]"
 
 clean: ## Remove virtual environment, Ollama, and local Cursor install
-	-$(PYTHON) scripts/cursor.py wipe
+	-$(PYTHON) scripts/cursor.py uninstall
 	rm -rf $(VENV) $(OLLAMA_DIR)
 
-cursor: $(VENV) ## Manage the local Cursor install: make cursor sync | make cursor wipe
-	$(PYTHON) scripts/cursor.py $(ARGS)
+cursor-install: $(VENV) ## Install this plugin into a local Cursor for development
+	$(PYTHON) scripts/cursor.py install
+
+cursor-uninstall: $(VENV) ## Uninstall this plugin from the local Cursor install
+	$(PYTHON) scripts/cursor.py uninstall
 
 lint: ## Run ruff linter checks
 	$(RUFF) check .
@@ -82,22 +80,22 @@ format: ## Auto-format code with ruff
 	$(RUFF) format .
 	$(RUFF) check --fix .
 
-test: ## Run all tests (pass a path to route to the correct runner automatically)
-ifdef ARGS
-	@if echo "$(ARGS)" | grep -q "tests/eval"; then \
-		$(MAKE) test-eval $(ARGS); \
+test: ## Run all tests (set testdir=<path> to route to the matching runner)
+ifdef testdir
+	@if echo "$(testdir)" | grep -q "tests/eval"; then \
+		$(MAKE) test-eval testdir="$(testdir)"; \
 	else \
-		$(MAKE) test-unit $(ARGS); \
+		$(MAKE) test-unit testdir="$(testdir)"; \
 	fi
 else
 	@$(MAKE) test-unit
 	@$(MAKE) test-eval
 endif
 
-test-unit: ## Run structural/unit validation tests (pass a path to target specific files)
-	$(PYTHON) -m pytest $(or $(ARGS),tests/unit/) -v
+test-unit: ## Run structural/unit validation tests (set testdir=<path> to target specific files)
+	$(PYTHON) -m pytest $(or $(testdir),tests/unit/) -v
 
-test-eval: ## Run LLM-judged tests (requires Ollama; pass a path to target specific files)
+test-eval: ## Run LLM-judged tests (requires Ollama; set testdir=<path> to target specific files)
 	@OLLAMA_PID=""; \
 	if ! OLLAMA_MODELS=$(OLLAMA_MODELS) $(OLLAMA_BIN) list > /dev/null 2>&1; then \
 		echo "Starting Ollama server..."; \
@@ -108,17 +106,10 @@ test-eval: ## Run LLM-judged tests (requires Ollama; pass a path to target speci
 			sleep 1; \
 		done; \
 	fi; \
-	$(DEEPEVAL) test run $(or $(ARGS),tests/eval/) -v; \
+	$(DEEPEVAL) test run $(or $(testdir),tests/eval/) -v; \
 	TEST_EXIT=$$?; \
 	if [ -n "$$OLLAMA_PID" ]; then \
 		echo "Stopping Ollama server (PID $$OLLAMA_PID)..."; \
 		kill $$OLLAMA_PID 2>/dev/null; \
 	fi; \
 	exit $$TEST_EXIT
-
-# Swallow path arguments (e.g. `make test-unit tests/unit/foo.py`) so they
-# aren't treated as targets. Caveat: this also makes typo'd targets like
-# `make tset-unit` a silent no-op instead of an error — double-check target
-# spelling.
-%:
-	@:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,12 @@ OLLAMA_MODEL := $(or $(OLLAMA_MODEL_NAME),gemma4)
 
 UNAME_S := $(shell uname -s)
 
-TARGETS := help install install-test install-tools clean lint format test test-unit test-eval
-ARGS := $(filter-out $(TARGETS),$(MAKECMDGOALS))
+TARGETS := help install install-test install-tools clean lint format test test-unit test-eval cursor
+# Positional: the first goal is the command (the target), everything after it is
+# arguments forwarded to that target's recipe. Unlike a $(filter-out)-based
+# approach this passes through words that happen to match a target name (e.g.
+# `make cursor wipe`), since only the leading goal is treated as the command.
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 
 .PHONY: $(TARGETS)
 
@@ -64,8 +68,12 @@ install-tools: $(VENV) ## Install linting/formatting tools (ruff)
 	$(PIP) install --upgrade pip
 	$(PIP) install -e ".[tools]"
 
-clean: ## Remove virtual environment and Ollama installation
+clean: ## Remove virtual environment, Ollama, and local Cursor install
+	-$(PYTHON) scripts/cursor.py wipe
 	rm -rf $(VENV) $(OLLAMA_DIR)
+
+cursor: $(VENV) ## Manage the local Cursor install: make cursor sync | make cursor wipe
+	$(PYTHON) scripts/cursor.py $(ARGS)
 
 lint: ## Run ruff linter checks
 	$(RUFF) check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "PT"]
-ignore = ["PT011"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["tests"]

--- a/scripts/cursor.py
+++ b/scripts/cursor.py
@@ -1,0 +1,147 @@
+import argparse
+import json
+import logging
+import shutil
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CLAUDE_DIR = Path.home() / ".claude"
+INSTALLED = CLAUDE_DIR / "plugins" / "installed_plugins.json"
+SETTINGS = CLAUDE_DIR / "settings.json"
+
+MARKETPLACE_NAME = "slack-dev"
+
+logger = logging.getLogger("cursor")
+
+
+def get_plugin_key(plugin_name: str):
+    return f"{plugin_name}@{MARKETPLACE_NAME}"
+
+
+def get_target_path():
+    return Path.home() / ".cursor" / "plugins" / MARKETPLACE_NAME
+
+
+def plugin_name() -> str:
+    """Read the plugin name from the Cursor manifest so renames are picked up."""
+    manifest = json.loads((REPO_ROOT / ".cursor-plugin" / "plugin.json").read_text())
+    return manifest["name"]
+
+
+PLUGIN_PATHS = (
+    ".claude-plugin",
+    ".cursor-plugin",
+    ".mcp.json",
+    ".cursor-mcp.json",
+    "skills",
+    "commands",
+)
+IGNORED_NAMES = frozenset({".DS_Store", "__pycache__"})
+
+
+def is_ignored(path: Path) -> bool:
+    return path.suffix == ".pyc" or bool(IGNORED_NAMES & set(path.parts))
+
+
+def plugin_files() -> list[Path]:
+    files = []
+    for name in PLUGIN_PATHS:
+        source = REPO_ROOT / name
+        if not source.exists():
+            continue
+        if source.is_file():
+            files.append(source)
+            continue
+        for path in source.rglob("*"):
+            if path.is_file() and not is_ignored(path):
+                files.append(path)
+    return files
+
+
+def load_json(path: Path) -> dict:
+    if not path.exists() or not path.read_text().strip():
+        return {}
+    return json.loads(path.read_text())
+
+
+def save_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def sync() -> None:
+    name = plugin_name()
+    plugin_key = get_plugin_key(name)
+    target = get_target_path()
+
+    shutil.rmtree(target, ignore_errors=True)
+    files = plugin_files()
+    if not files:
+        logger.warning(f"No plugin files found under {REPO_ROOT} — nothing to sync")
+        return
+    for source in files:
+        dest = target / source.relative_to(REPO_ROOT)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+    logger.info(f"Copied {len(files)} files to {target}")
+
+    installed = load_json(INSTALLED)
+    installed.setdefault("plugins", {})[plugin_key] = [{"scope": "user", "installPath": str(target)}]
+    save_json(INSTALLED, installed)
+    logger.info(f"Registered '{plugin_key}' in {INSTALLED}")
+
+    settings = load_json(SETTINGS)
+    settings.setdefault("enabledPlugins", {})[plugin_key] = True
+    save_json(SETTINGS, settings)
+    logger.info(f"Enabled '{plugin_key}' in {SETTINGS}")
+
+    logger.info("Reload plugins in Cursor to pick up the changes.")
+
+
+def wipe() -> None:
+    name = plugin_name()
+    plugin_key = get_plugin_key(name)
+    target = get_target_path()
+
+    shutil.rmtree(target, ignore_errors=True)
+    logger.info(f"Removed {target}")
+
+    installed = load_json(INSTALLED)
+    if installed.get("plugins", {}).pop(plugin_key, None) is not None:
+        save_json(INSTALLED, installed)
+        logger.info(f"Wiped '{plugin_key}' from {INSTALLED}")
+    else:
+        logger.warning(f"'{plugin_key}' already wiped from {INSTALLED}")
+
+    settings = load_json(SETTINGS)
+    if settings.get("enabledPlugins", {}).pop(plugin_key, None) is not None:
+        save_json(SETTINGS, settings)
+        logger.info(f"Wiped '{plugin_key}' from {SETTINGS}")
+    else:
+        logger.warning(f"'{plugin_key}' already wiped from {SETTINGS}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="cursor.py",
+        description=(
+            "Install or remove this plugin in a local Cursor for development. "
+            "Copies the plugin files into ~/.cursor/plugins, then registers and "
+            "enables it via ~/.claude/."
+        ),
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("sync", help="Install this plugin into a local Cursor (~/.cursor/plugins)").set_defaults(
+        func=sync
+    )
+    subcommands.add_parser("wipe", help="Remove this plugin from a local Cursor install").set_defaults(func=wipe)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    args = parser.parse_args()
+    args.func()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cursor.py
+++ b/scripts/cursor.py
@@ -4,59 +4,58 @@ import logging
 import shutil
 from pathlib import Path
 
+logger = logging.getLogger(Path(__file__).stem)
+
+INCLUDE: set[str] = {
+    ".claude-plugin/**/*",
+    ".cursor-plugin/**/*",
+    ".mcp.json",
+    ".cursor-mcp.json",
+    "skills/**/*",
+    "commands/**/*",
+}
+EXCLUDE: set[str] = {
+    "**/.DS_Store",
+    "**/__pycache__/**",
+    "**/*.pyc",
+}
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-CLAUDE_DIR = Path.home() / ".claude"
-INSTALLED = CLAUDE_DIR / "plugins" / "installed_plugins.json"
-SETTINGS = CLAUDE_DIR / "settings.json"
+CLAUDE_HOME_DIR = Path.home() / ".claude"
+CLAUDE_INSTALLED_PLUGINS_PATH = CLAUDE_HOME_DIR / "plugins" / "installed_plugins.json"
+CLAUDE_SETTINGS_PATH = CLAUDE_HOME_DIR / "settings.json"
 
-MARKETPLACE_NAME = "slack-dev"
+CURSOR_PLUGINS_PATH = Path.home() / ".cursor" / "plugins"
 
-logger = logging.getLogger("cursor")
+MARKETPLACE_NAME = "local"
 
 
 def get_plugin_key(plugin_name: str):
     return f"{plugin_name}@{MARKETPLACE_NAME}"
 
 
-def get_target_path():
-    return Path.home() / ".cursor" / "plugins" / MARKETPLACE_NAME
+def get_target_path(plugin_key: str):
+    return CURSOR_PLUGINS_PATH / plugin_key
 
 
 def plugin_name() -> str:
-    """Read the plugin name from the Cursor manifest so renames are picked up."""
-    manifest = json.loads((REPO_ROOT / ".cursor-plugin" / "plugin.json").read_text())
-    return manifest["name"]
+    """Read the plugin name from the Cursor plugin file so renames are picked up."""
+    cursor_plugin = json.loads(
+        (REPO_ROOT / ".cursor-plugin" / "plugin.json").read_text()
+    )
+    return cursor_plugin["name"]
 
 
-PLUGIN_PATHS = (
-    ".claude-plugin",
-    ".cursor-plugin",
-    ".mcp.json",
-    ".cursor-mcp.json",
-    "skills",
-    "commands",
-)
-IGNORED_NAMES = frozenset({".DS_Store", "__pycache__"})
-
-
-def is_ignored(path: Path) -> bool:
-    return path.suffix == ".pyc" or bool(IGNORED_NAMES & set(path.parts))
-
-
-def plugin_files() -> list[Path]:
-    files = []
-    for name in PLUGIN_PATHS:
-        source = REPO_ROOT / name
-        if not source.exists():
-            continue
-        if source.is_file():
-            files.append(source)
-            continue
-        for path in source.rglob("*"):
-            if path.is_file() and not is_ignored(path):
-                files.append(path)
-    return files
+def plugin_files() -> set[Path]:
+    included = {
+        path
+        for pattern in INCLUDE
+        for path in REPO_ROOT.glob(pattern)
+        if path.is_file()
+    }
+    excluded = {path for pattern in EXCLUDE for path in REPO_ROOT.glob(pattern)}
+    return included - excluded
 
 
 def load_json(path: Path) -> dict:
@@ -70,72 +69,86 @@ def save_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def sync() -> None:
+def install() -> None:
     name = plugin_name()
     plugin_key = get_plugin_key(name)
-    target = get_target_path()
+    target = get_target_path(plugin_key)
 
-    shutil.rmtree(target, ignore_errors=True)
     files = plugin_files()
     if not files:
-        logger.warning(f"No plugin files found under {REPO_ROOT} — nothing to sync")
+        logger.warning(f"No plugin files found under {REPO_ROOT}; nothing to install")
         return
+
+    shutil.rmtree(target, ignore_errors=True)
     for source in files:
         dest = target / source.relative_to(REPO_ROOT)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, dest)
-    logger.info(f"Copied {len(files)} files to {target}")
+    logger.info(f"Copied {len(files)} plugin files to {target}")
 
-    installed = load_json(INSTALLED)
-    installed.setdefault("plugins", {})[plugin_key] = [{"scope": "user", "installPath": str(target)}]
-    save_json(INSTALLED, installed)
-    logger.info(f"Registered '{plugin_key}' in {INSTALLED}")
+    installed = load_json(CLAUDE_INSTALLED_PLUGINS_PATH)
+    installed.setdefault("plugins", {})[plugin_key] = [
+        {"scope": "user", "installPath": str(target)}
+    ]
+    save_json(CLAUDE_INSTALLED_PLUGINS_PATH, installed)
+    logger.info(f"Registered '{plugin_key}' in {CLAUDE_INSTALLED_PLUGINS_PATH}")
 
-    settings = load_json(SETTINGS)
+    settings = load_json(CLAUDE_SETTINGS_PATH)
     settings.setdefault("enabledPlugins", {})[plugin_key] = True
-    save_json(SETTINGS, settings)
-    logger.info(f"Enabled '{plugin_key}' in {SETTINGS}")
+    save_json(CLAUDE_SETTINGS_PATH, settings)
+    logger.info(f"Enabled '{plugin_key}' in {CLAUDE_SETTINGS_PATH}")
 
-    logger.info("Reload plugins in Cursor to pick up the changes.")
+    logger.info(
+        f"Installed '{plugin_key}'. Reload plugins in Cursor to pick up the changes."
+    )
 
 
-def wipe() -> None:
+def uninstall() -> None:
     name = plugin_name()
     plugin_key = get_plugin_key(name)
-    target = get_target_path()
+    target = get_target_path(plugin_key)
 
-    shutil.rmtree(target, ignore_errors=True)
-    logger.info(f"Removed {target}")
+    if target.exists():
+        shutil.rmtree(target, ignore_errors=True)
+        logger.info(f"Removed plugin files from {target}")
+    else:
+        logger.warning(f"No plugin files found at {target}; nothing to remove")
 
-    installed = load_json(INSTALLED)
+    installed = load_json(CLAUDE_INSTALLED_PLUGINS_PATH)
     if installed.get("plugins", {}).pop(plugin_key, None) is not None:
-        save_json(INSTALLED, installed)
-        logger.info(f"Wiped '{plugin_key}' from {INSTALLED}")
+        save_json(CLAUDE_INSTALLED_PLUGINS_PATH, installed)
+        logger.info(f"Deregistered '{plugin_key}' from {CLAUDE_INSTALLED_PLUGINS_PATH}")
     else:
-        logger.warning(f"'{plugin_key}' already wiped from {INSTALLED}")
+        logger.warning(
+            f"'{plugin_key}' was not registered in {CLAUDE_INSTALLED_PLUGINS_PATH}; nothing to remove"
+        )
 
-    settings = load_json(SETTINGS)
+    settings = load_json(CLAUDE_SETTINGS_PATH)
     if settings.get("enabledPlugins", {}).pop(plugin_key, None) is not None:
-        save_json(SETTINGS, settings)
-        logger.info(f"Wiped '{plugin_key}' from {SETTINGS}")
+        save_json(CLAUDE_SETTINGS_PATH, settings)
+        logger.info(f"Disabled '{plugin_key}' in {CLAUDE_SETTINGS_PATH}")
     else:
-        logger.warning(f"'{plugin_key}' already wiped from {SETTINGS}")
+        logger.warning(
+            f"'{plugin_key}' was not enabled in {CLAUDE_SETTINGS_PATH}; nothing to remove"
+        )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        prog="cursor.py",
+        prog=Path(__file__).name,
         description=(
             "Install or remove this plugin in a local Cursor for development. "
-            "Copies the plugin files into ~/.cursor/plugins, then registers and "
-            "enables it via ~/.claude/."
+            f"Copies the plugin files into {CURSOR_PLUGINS_PATH}, then registers and "
+            f"enables it via {CLAUDE_HOME_DIR}"
         ),
     )
     subcommands = parser.add_subparsers(dest="command", required=True)
-    subcommands.add_parser("sync", help="Install this plugin into a local Cursor (~/.cursor/plugins)").set_defaults(
-        func=sync
-    )
-    subcommands.add_parser("wipe", help="Remove this plugin from a local Cursor install").set_defaults(func=wipe)
+    subcommands.add_parser(
+        "install", help=f"Install this plugin into local Cursor ({CURSOR_PLUGINS_PATH})"
+    ).set_defaults(func=install)
+    subcommands.add_parser(
+        "uninstall", help="Uninstall this plugin from local Cursor"
+    ).set_defaults(func=uninstall)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 


### PR DESCRIPTION
## Summary

Adds a developer workflow for testing this plugin against a **local Cursor install**.

- **`scripts/cursor.py`**:
    - copies the plugin files into `~/.cursor/plugins/slack@local/`
    - registers and enables the plugin via `~/.claude/` (`install`)
    - tears it all back down (`uninstall`).
    - The plugin name is read from the Cursor manifest, so renames are picked up automatically.

## How to test against Cursor locally

1. **Install the plugin into your local Cursor:**
   ```bash
   make cursor-install
   ```
   You should see log lines confirming the files were copied and the `slack@local` plugin was registered and enabled.

2. **Reload Cursor**.

3. **Verify the plugin loaded** — open Cursor and confirm:
   - The Slack MCP server appears and you can authenticate via OAuth.
   - The skills (`block-kit`, `slack-search`, `slack-messaging`, etc.) and commands (`/summarize-channel`, `/standup`, …) are available.
   - Try a command end-to-end, e.g. ask it to summarize a channel.

4. **Clean up** when done:
   ```bash
   make cursor-uninstall
   ```
   This removes `~/.cursor/plugins/slack@local/` and the plugin entries from `~/.claude/`. (`make clean` also runs this.)

## Notes / open questions

- This is a **dev-only** tool; it is not part of the published plugin and doesn't run in CI

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>