### PR TITLE
fix: update stale skill cross-references to slack:skill-name

### DIFF
--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -180,9 +180,9 @@ Prefer the Slack CLI when it's available, since it reuses the slack-cli skill's 
 
 **Path A: Slack CLI (preferred).**
 
-Use the `slack-developer:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
+Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
 
-If the CLI is available, use the `slack-developer:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**, to invoke it. That step covers the `SLACK_CMD api <method> key=value …` syntax. Run `SLACK_CMD api --help` first to confirm the syntax **and the flag that skips authentication**. `blocks.validate` needs no token, so call it without authentication. Don't hard-code that flag from memory; read it from the help output so this stays correct if it's ever renamed. Pass the payload as a positional `key=value` argument: `blocks=<JSON array>` for messages, or `view=<JSON view object>` for modals and home tabs.
+If the CLI is available, use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**, to invoke it. That step covers the `SLACK_CMD api <method> key=value …` syntax. Run `SLACK_CMD api --help` first to confirm the syntax **and the flag that skips authentication**. `blocks.validate` needs no token, so call it without authentication. Don't hard-code that flag from memory; read it from the help output so this stays correct if it's ever renamed. Pass the payload as a positional `key=value` argument: `blocks=<JSON array>` for messages, or `view=<JSON view object>` for modals and home tabs.
 
 **Path B: curl (fallback, when the CLI isn't installed).**
 
@@ -259,7 +259,7 @@ Present the validated payload, then help the developer put it to use.
 
 ### Send it
 
-Building the payload is this skill's job; sending it (`chat.postMessage`, `views.open`, `views.publish`, and the token/scope handling around them) belongs to the Web API layer. To call the right method — via the Slack CLI, raw curl, or a Bolt SDK — use the `slack-developer:slack-api` skill, **Step 4: Call the Method (Manage)**, passing this payload as the method's `blocks` argument (messages) or `view` argument (modals and home tabs). That skill matches the argument names to the SDK or HTTP call so we don't duplicate them here.
+Building the payload is this skill's job; sending it (`chat.postMessage`, `views.open`, `views.publish`, and the token/scope handling around them) belongs to the Web API layer. To call the right method — via the Slack CLI, raw curl, or a Bolt SDK — use the `slack:slack-api` skill, **Step 4: Call the Method (Manage)**, passing this payload as the method's `blocks` argument (messages) or `view` argument (modals and home tabs). That skill matches the argument names to the SDK or HTTP call so we don't duplicate them here.
 
 ### Preview it
 
@@ -275,5 +275,5 @@ Ask whether the developer wants to add, modify, remove, or reorder blocks, or bu
 
 ## Notes
 
-- **Scope:** this skill owns building and validating the Block Kit payload — choosing the surface, composing the JSON from the live docs, and confirming it with `blocks.validate`. Sending it lives in the Web API layer (`slack-developer:slack-api`), and CLI detection/auth in `slack-developer:slack-cli`.
+- **Scope:** this skill owns building and validating the Block Kit payload — choosing the surface, composing the JSON from the live docs, and confirming it with `blocks.validate`. Sending it lives in the Web API layer (`slack:slack-api`), and CLI detection/auth in `slack:slack-cli`.
 - **`blocks.validate` needs no auth** — it's a public method, so it works without a token whether you call it via the CLI or curl. Always validate before finalizing (Step 5).

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -16,7 +16,7 @@ This skill walks through the full setup: prerequisites, authentication, sandbox 
 
 ### 1a. Detect the Slack CLI command
 
-Use the `slack-developer:slack-cli` skill — **Step 1: Detect the Slack CLI** — to check whether the public Slack CLI is installed and resolve its command name. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here.
+Use the `slack:slack-cli` skill — **Step 1: Detect the Slack CLI** — to check whether the public Slack CLI is installed and resolve its command name. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here.
 
 Once resolved, use the detected command name for **all** CLI commands throughout the rest of this skill. We refer to it as `SLACK_CMD` below — substitute the actual resolved command name everywhere you see `SLACK_CMD`.
 
@@ -33,7 +33,7 @@ Run `SLACK_CMD version` and print the version to confirm everything is working b
 
 ## Step 2: Authenticate with the Slack CLI
 
-Use the `slack-developer:slack-cli` skill — **Step 5: Authentication (`slack auth`)** — to check the developer's auth status and walk them through `SLACK_CMD login` if they're not already authenticated.
+Use the `slack:slack-cli` skill — **Step 5: Authentication (`slack auth`)** — to check the developer's auth status and walk them through `SLACK_CMD login` if they're not already authenticated.
 
 Wait for confirmation that authentication succeeded before proceeding.
 
@@ -151,7 +151,7 @@ cd my-slack-agent && SLACK_CMD env set ANTHROPIC_API_KEY sk-ant-...
 
 ## Step 5: Run the App Locally
 
-Use the `slack-developer:slack-cli` skill — **Step 6: Running an App Locally (`slack run`)** — to resolve the app or team target and start the dev server in the background.
+Use the `slack:slack-cli` skill — **Step 6: Running an App Locally (`slack run`)** — to resolve the app or team target and start the dev server in the background.
 
 Tell the developer their app is now running and installed in their sandbox workspace, and that file changes will auto-reload it.
 

--- a/skills/slack-api/SKILL.md
+++ b/skills/slack-api/SKILL.md
@@ -63,7 +63,7 @@ Never publish or call a method name you have not seen on a live page.
 
 ### Searching the docs
 
-When you would rather search by keyword than scan the index, and the Slack CLI is available, use the `slack-developer:slack-cli` skill — **Step 3: Searching Documentation (`slack docs search`)** — to query Slack's docs from the terminal. That step covers the command and flags; results will point you to the method's reference page, which you then read in Step 2. Without the CLI, WebFetch the index (`https://docs.slack.dev/reference/methods.md`) and scan it instead.
+When you would rather search by keyword than scan the index, and the Slack CLI is available, use the `slack:slack-cli` skill — **Step 3: Searching Documentation (`slack docs search`)** — to query Slack's docs from the terminal. That step covers the command and flags; results will point you to the method's reference page, which you then read in Step 2. Without the CLI, WebFetch the index (`https://docs.slack.dev/reference/methods.md`) and scan it instead.
 
 ---
 
@@ -108,11 +108,11 @@ You need a token only when the method requires one. There are two ways to get on
 
 The CLI supplies an authenticated session, so once the developer is logged in you can call methods without handling a token yourself (Step 4, "Via the Slack CLI").
 
-Use the `slack-developer:slack-cli` skill — **Step 1: Detect the Slack CLI** — to check whether the public Slack CLI is installed and resolve its command name. That step also proposes installing the CLI when it is absent. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here.
+Use the `slack:slack-cli` skill — **Step 1: Detect the Slack CLI** — to check whether the public Slack CLI is installed and resolve its command name. That step also proposes installing the CLI when it is absent. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here.
 
 Once resolved, use the detected command name for **all** CLI commands in this skill. We refer to it as `SLACK_CMD` — substitute the actual resolved command name everywhere you see `SLACK_CMD`.
 
-Use the `slack-developer:slack-cli` skill — **Step 5: Authentication (`slack auth`)** — to check the developer's login state and, if needed, walk them through `slack login`. Authentication mechanics live there.
+Use the `slack:slack-cli` skill — **Step 5: Authentication (`slack auth`)** — to check the developer's login state and, if needed, walk them through `slack login`. Authentication mechanics live there.
 
 ### Path B: No CLI — bring your own token
 
@@ -126,7 +126,7 @@ First apply the **execution posture**: if the method changes state (post/update/
 
 ### Via the Slack CLI (if installed)
 
-To call a method from the terminal, use the `slack-developer:slack-cli` skill — **Step 4: Calling Web API Methods (`slack api`)**. That step covers the `SLACK_CMD api <method> key=value …` syntax so that it is not repeated here. Pass the required arguments you gathered from the method's doc page in Step 2.
+To call a method from the terminal, use the `slack:slack-cli` skill — **Step 4: Calling Web API Methods (`slack api`)**. That step covers the `SLACK_CMD api <method> key=value …` syntax so that it is not repeated here. Pass the required arguments you gathered from the method's doc page in Step 2.
 
 The CLI uses the developer's authenticated session, so it is the simplest path once they are logged in (Step 3).
 
@@ -160,7 +160,7 @@ In Bolt and the Slack SDKs, each method is a client function whose arguments mat
 - **JavaScript:** `await client.chat.postMessage({ channel, text, blocks })`
 - **Python:** `client.chat_postMessage(channel=channel, text=text, blocks=blocks)`
 
-(Note the JS dot form `chat.postMessage` vs the Python underscore form `chat_postMessage`.) To construct the `blocks`/`view` payload these calls take, use the `slack-developer:block-kit` skill — this skill treats that payload as an opaque argument and focuses on the method call around it.
+(Note the JS dot form `chat.postMessage` vs the Python underscore form `chat_postMessage`.) To construct the `blocks`/`view` payload these calls take, use the `slack:block-kit` skill — this skill treats that payload as an opaque argument and focuses on the method call around it.
 
 ---
 
@@ -204,4 +204,4 @@ When `ok` is `false`, branch on the `error` string:
 ## Notes
 
 - **Slack Lists** methods use the `slackLists.*` prefix — a bare `lists.*` name does not exist.
-- **Scope:** this skill owns the method layer — which method, its contract, and the call around it. CLI auth and calls are delegated to `slack-developer:slack-cli`; Block Kit payloads to `slack-developer:block-kit`.
+- **Scope:** this skill owns the method layer — which method, its contract, and the call around it. CLI auth and calls are delegated to `slack:slack-cli`; Block Kit payloads to `slack:block-kit`.

--- a/skills/slack-cli/SKILL.md
+++ b/skills/slack-cli/SKILL.md
@@ -7,7 +7,7 @@ description: Use the Slack CLI to create, run, and manage Slack apps from the te
 
 Use the Slack CLI to create, run, and manage Slack apps — including calling Web API methods directly and searching Slack developer documentation from the terminal.
 
-For initial setup (sandbox creation, project scaffolding from templates), use the `slack-developer:create-slack-app` skill instead.
+For initial setup (sandbox creation, project scaffolding from templates), use the `slack:create-slack-app` skill instead.
 
 ---
 


### PR DESCRIPTION
### Summary

This pull request fixes stale skill cross-references in the developer skills ported from `slackapi/slack-developer-skills` in #50.

- The plugin manifest names this plugin `slack`, but the ported skills referenced siblings as `slack-developer:<skill>` - the prefix from the original, prototype repo. At runtime those references resolved to nothing.
- Body-only string change; no frontmatter, code, or links touched.

Thank you @lukegalbraithrussell for reporting this issue. 🙇🏻 

### Testing

- N/A
- I considered adding a regression test to lint all skill name references, but I decided against it.