### PR TITLE
fix(commands): use standard markdown for bold in command output

### DIFF
--- a/commands/channel-digest.md
+++ b/commands/channel-digest.md
@@ -14,13 +14,13 @@ Given the comma-separated channel names provided in $ARGUMENTS (strip leading `#
 3. Present the digest in this format:
 
    ```
-   *Channel Digest — <today's date>*
+   **Channel Digest — <today's date>**
 
-   *#channel-1*
+   **#channel-1**
    - Summary point 1
    - Summary point 2
 
-   *#channel-2*
+   **#channel-2**
    - Summary point 1
    - Summary point 2
 

--- a/commands/draft-announcement.md
+++ b/commands/draft-announcement.md
@@ -12,7 +12,7 @@ Given the topic or context provided in $ARGUMENTS:
    - What tone is appropriate — formal, casual, or urgent?
 
 2. Compose the announcement following Slack formatting best practices:
-   - Use Slack's mrkdwn syntax: `*bold*` for emphasis (not `**bold**`), `_italic_` for secondary emphasis, `>` for callouts.
+   - Use standard markdown: `**bold**` for emphasis, `_italic_` for secondary emphasis, `>` for callouts.
    - Lead with the most important information — don't bury the point.
    - Use a clear, descriptive opening line that works as a headline.
    - Keep paragraphs short (2-3 sentences max).

--- a/commands/standup.md
+++ b/commands/standup.md
@@ -15,16 +15,16 @@ description: Generate a standup update based on your recent Slack activity
 
 5. Format the standup as:
    ```
-   *Standup for <display name> — <today's date>*
+   **Standup for <display name> — <today's date>**
 
-   *Done:*
+   **Done:**
    - Item 1
    - Item 2
 
-   *Doing:*
+   **Doing:**
    - Item 1
 
-   *Blockers:*
+   **Blockers:**
    - None / Item 1
    ```
 


### PR DESCRIPTION
## What this fixes/addresses

The `channel-digest`, `draft-announcement`, and `standup` commands tell the
assistant to format bold with a single asterisk (`*text*`), Slack's older
mrkdwn convention. Standard markdown reads a single asterisk (or underscore) as *italic* and
requires double asterisks for **bold**. So wherever the command output lands in a
standard-markdown surface, the intended bold renders as italic. That includes
**markdown files** and the **Slack MCP server**, which expects standard markdown
(so, for instance, `draft-announcement` writes a malformed-bold draft into Slack).

## How I found it

I ran `/slack:channel-digest` and saved the output into a markdown file. The
digest's bold headers (the "Channel Digest" title and the `#channel` names)
showed up italic instead of bold. Tracing it to the command template, it emits
single-asterisk bold. Found the same pattern in `draft-announcement`
(which even explicitly says to use `*bold*` "not `**bold**`") and `standup` as well,
so this PR fixes all three. This also aligns the commands with the
`slack-messaging` skill, which already documents standard markdown (`**bold**`).

## How to reproduce

1. Run `/slack:channel-digest <channel>` on `main` against any channel, and
   capture the output to a markdown file (or post it to Slack).
2. The headers come out as `*...*` and render *italic*.
3. On this branch, the same command emits `**...**` and renders **bold**.
4. `draft-announcement` behaves the same: it writes the announcement as a Slack
   draft, so the malformed bold shows up directly in Slack (see screenshots).

## The fix

- `commands/channel-digest.md` — digest header lines to `**...**`
- `commands/draft-announcement.md` — formatting instruction to standard markdown
- `commands/standup.md` — standup header lines to `**...**`

## Screenshots & verification

I verified end to end: created throwaway test channels, posted test messages, and ran
the affected commands both before and after the fix (reloading the plugin in
between). Before rendered italic; after rendered bold.

### Markdown file (`channel-digest`)

- **Before** (single asterisk, renders italic):
<img width="1171" height="337" alt="channel-digest after" src="https://github.com/user-attachments/assets/5d94f63e-45a1-4d89-a7fa-a840ce37ad56" />

- **After** (double asterisk, renders bold):
<img width="1171" height="337" alt="channel-digest before" src="https://github.com/user-attachments/assets/208fdbe0-83a4-4f92-856a-622a89b70b16" />

### Slack draft (`draft-announcement`)

- **Before** (single asterisk, renders italic):
<img width="992" height="864" alt="Screenshot 2026-06-20 at 11 17 00 PM" src="https://github.com/user-attachments/assets/962552d1-fa05-423f-a5a9-f2877689ea5d" />

- **After** (double asterisk, renders bold):
<img width="992" height="864" alt="Screenshot 2026-06-20 at 11 11 08 PM" src="https://github.com/user-attachments/assets/2ec2d624-b55b-445a-9abd-cdd49d4d6294" />

