### PR TITLE
chore: add slack-skills-plugin-team as default CODEOWNERS team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,11 @@
 #ECCN:Open Source
 #GUSINFO:Open Source,Open Source Workflow
 
-# @slackapi/developer-education
-# are code reviewers for changes in the `/docs` directory.
+# * @slackapi/slack-skills-plugin-team will be added as code reviewers
+# to all files in this repo.
+* @slackapi/slack-skills-plugin-team
+
+# @slackapi/developer-education owns any file in the
+# `/docs` directory in the root of this repo and any
+# of its subdirectories.
 /docs/ @slackapi/developer-education


### PR DESCRIPTION
### Summary

This pull request sets `@slackapi/slack-skills-plugin-team` as the default reviewer for all files in the repo.

- Adds `* @slackapi/slack-skills-plugin-team` so every PR is auto-assigned to the team.
- Keeps `@slackapi/developer-education` on `/docs/`.