### PR TITLE
fix: document Slack Connect MCP send restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Once installed, talk to your tool in natural language:
 ## Limitations
 
 - **Workspace admin approval.** Your Slack workspace admin must approve MCP integration before you can authenticate.
+- **Slack Connect message sends.** The hosted Slack MCP server currently rejects `slack_send_message` calls to
+  externally shared Slack Connect channels and returns `mcp_externally_shared_channel_restricted`. The channel may
+  still be searchable and readable if your authenticated user has access, but sending through MCP is blocked. Send the
+  message in Slack directly or use a workspace-approved non-MCP integration for that workflow.
 
 ## Contributing
 

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -47,6 +47,15 @@ Not supported:
 - **Post in the channel** (not a thread) when starting a new topic, making an announcement, or asking a question to the whole group.
 - **Don't start a new thread** to continue an existing conversation — find and reply to the original message.
 
+## Delivery Errors
+
+- If `slack_send_message` fails with `mcp_externally_shared_channel_restricted`, the hosted Slack MCP server is blocking
+  the send because the target is an externally shared Slack Connect channel. Do not retry the same MCP send. Tell the
+  user that Slack Connect sends are currently restricted through MCP, and suggest sending the message directly in Slack
+  or using a workspace-approved non-MCP integration for that channel.
+- If sending is blocked, preserve the drafted message text so the user can post it manually without asking you to
+  reconstruct it.
+
 ## Tone and Audience
 
 - Match the tone to the channel — `#general` is usually more formal than `#random`.

--- a/tests/unit/test_slack_connect_guidance.py
+++ b/tests/unit/test_slack_connect_guidance.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ERROR_CODE = "mcp_externally_shared_channel_restricted"
+
+
+def test_readme_documents_slack_connect_send_restriction():
+    readme = (ROOT / "README.md").read_text()
+
+    assert ERROR_CODE in readme
+    assert "Slack Connect" in readme
+    assert "slack_send_message" in readme
+
+
+def test_slack_messaging_skill_explains_slack_connect_send_error():
+    skill = (ROOT / "skills/slack-messaging/SKILL.md").read_text()
+
+    assert ERROR_CODE in skill
+    assert "Do not retry" in skill
+    assert "preserve the drafted message text" in skill


### PR DESCRIPTION
## Summary

Addresses #33.

- Document the current hosted Slack MCP `slack_send_message` restriction for externally shared Slack Connect channels in the README limitations.
- Add `slack-messaging` guidance for the `mcp_externally_shared_channel_restricted` error so agents explain the restriction, avoid retrying the same send, and preserve the drafted message text for manual posting.
- Add a unit regression test that keeps the README and skill guidance tied to the server error code.

## Root cause

The hosted Slack MCP server can return `mcp_externally_shared_channel_restricted` for `slack_send_message` calls to externally shared Slack Connect channels. This plugin packages the hosted MCP endpoint and skills rather than the hosted server implementation, so the change documents the current limitation and makes the agent-facing behavior actionable.

## Validation

- `make lint`
- `make test-unit`

Note: `make install` was started per repo guidance, but stopped before the default `gemma4` eval model download completed because it was pulling a 9.6 GB model. Test and lint dependencies were installed successfully before stopping it; CI only runs lint and unit tests.
