### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Summary
+
+(Please describe the goal of this pull request and mention any related issue numbers)
+
+### Preview
+
+(Add screenshots, GIFs, or recordings that show the changes)
+
+### Testing
+
+(List the steps used to verify these changes)
+
+### Notes
+
+(Add any additional context, trade-offs, or follow-up items)
+
+### Requirements
+
+- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
+- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
+- [ ] I've run `make test` and the tests pass.


### PR DESCRIPTION
### Summary

This pull request adds a default pull request template so new PRs open with a consistent structure.

Layout is based on [slackapi/slack-cli](https://github.com/slackapi/slack-cli/blob/main/.github/pull_request_template.md) and [slackapi/bolt-python](https://github.com/slackapi/bolt-python/blob/main/.github/pull_request_template.md).

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.