### PR TITLE
ci: publish GitHub Releases from changesets release step

### DIFF
--- a/.changeset/publish-github-releases.md
+++ b/.changeset/publish-github-releases.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Publish GitHub Releases from the release workflow so each tag has release notes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           version: bash scripts/changeset_version.sh
           publish: npx changeset publish
+          createGithubReleases: true
           commit: "chore: release"
           title: "chore: release"
           prDraft: create


### PR DESCRIPTION
### Summary

This pull request create a GitHub Release in our release action:

- Add `createGithubReleases: true` to the `changesets/action` step in `.github/workflows/release.yml` so each `slack@<version>` tag lands on a populated GitHub Release page, using the auto-generated notes template already staged in `.github/release.yml`. No new permissions needed — the job already has `contents: write`.

### Preview

- N/A

### Testing

- Ran `make lint` locally - passes.
- Post-merge verification (on the next real release): the `Changesets release` step should succeed with no permissions errors, and `https://github.com/slackapi/slack-mcp-plugin/releases/tag/slack@<version>` should render a populated release with categorized notes from `.github/release.yml`, rather than the empty tag page we get today.

### Notes

- Using the `test` label until we have a proper label for this type of work.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.