### PR TITLE
chore: add build/chore/security labels and release notes categories

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -111,7 +111,7 @@ Patch and minor updates are auto-approved and auto-merged via the
 - Feature requests for new skills should be discussed in the issue before
   implementation begins.
 - Labels: `bug` for confirmed issues, `enhancement` for feature requests,
-  `build` for CI/tooling changes.
+  `chore` for CI/tooling changes.
 
 ---
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -110,8 +110,16 @@ Patch and minor updates are auto-approved and auto-merged via the
   checking whether the relevant live `docs.slack.dev` page has changed.
 - Feature requests for new skills should be discussed in the issue before
   implementation begins.
-- Labels: `bug` for confirmed issues, `enhancement` for feature requests,
-  `chore` for CI/tooling changes.
+- Labels:
+  - `bug` — confirmed defects
+  - `enhancement` — feature requests and new functionality
+  - `docs` — documentation-only changes
+  - `test` — test-only changes
+  - `build` — CI, GitHub Actions, and build/compilation processes
+  - `chore` — repo structure, required files, release scaffolding, general maintenance
+  - `dependencies` — dependency updates (Dependabot applies this automatically)
+  - `security` — vulnerability fixes, hardening, and security audit findings
+    (apply alongside `bug`/`build`/`dependencies` as appropriate)
 
 ---
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,7 +9,7 @@ changelog:
         - bug
     - title: 📚 Documentation
       labels:
-        - documentation
+        - docs
     - title: 🧪 Tests
       labels:
         - test

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,6 +10,9 @@ changelog:
     - title: 📚 Documentation
       labels:
         - docs
+    - title: 🤖 Build
+      labels:
+        - build
     - title: 🧪 Tests
       labels:
         - test

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,9 @@ changelog:
     - title: 🐛 Bug Fixes
       labels:
         - bug
+    - title: 🔒 Security
+      labels:
+        - security
     - title: 📚 Documentation
       labels:
         - docs
@@ -22,9 +25,6 @@ changelog:
     - title: ⬆️ Dependencies
       labels:
         - dependencies
-    - title: 🔒 Security
-      labels:
-        - security
     - title: 📦 Other changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,9 +1,6 @@
 # https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
 changelog:
   categories:
-    - title: 🔒 Security
-      labels:
-        - security
     - title: 🚀 Enhancements
       labels:
         - enhancement
@@ -22,6 +19,9 @@ changelog:
     - title: ⬆️ Dependencies
       labels:
         - dependencies
+    - title: 🔒 Security
+      labels:
+        - security
     - title: 📦 Other changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 # https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
 changelog:
   categories:
+    - title: 🔒 Security
+      labels:
+        - security
     - title: 🚀 Enhancements
       labels:
         - enhancement
@@ -9,16 +12,16 @@ changelog:
         - bug
     - title: 📚 Documentation
       labels:
-        - docs
-    - title: 🤖 Build
+        - documentation
+    - title: 🧪 Tests
       labels:
-        - build
-    - title: 🧪 Testing/Code Health
+        - test
+    - title: 🧹 Chores
       labels:
-        - code health
-    - title: 🔒 Security
+        - chore
+    - title: ⬆️ Dependencies
       labels:
-        - security
+        - dependencies
     - title: 📦 Other changes
       labels:
         - "*"


### PR DESCRIPTION
### Summary

This pull request introduces 3 new labels (`chore`, `build`, and `security`) and fixes the `.github/release.yml` to not use non-existent labels.

- Adds a `chore` label for maintainer task PRs.
  - e.g. repo structure, required files, release scaffolding, general maintenance work - matching the conventional-commit `chore:` prefix.
- Adds a `build` label for changes to compilation and CI processes
  - e.g. build, ci/cd, scripts, etc
- Adds a `security` label so security fixes surface distinctly in release notes.
- Aligns `.github/release.yml` with the labels that actually exist on the repo.
  - The prior config referenced four non-existent labels (`build`, `code health`, `docs`, `security`), so those changelog sections silently fell through to "Other changes."
  - The `documentation` label was renamed to `docs` to match other slackapi projects.

### Preview

```markdown
  What's Changed

  🚀 Enhancements

  - feat: add /slack:channel-digest command by @WilliamBergamin in #55
  - feat: support --dry-run flag on draft-announcement by @mwbrooks in #82

  🐛 Bug Fixes

  - fix: handle empty channel IDs in summarize-channel gracefully by @mwbrooks in #78
  - fix: correct block-kit validation for section blocks by @WilliamBergamin in #85

  📚 Documentation

  - docs: clarify Ollama setup in AGENTS.md by @WilliamBergamin in #58
  - docs: add screenshots to draft-announcement walkthrough by @mwbrooks in #91

  🤖 Build

  - ci: automate versioning and releases with changesets by @WilliamBergamin in #60
  - ci: publish GitHub Releases from changesets release step by @WilliamBergamin in #71

  🧪 Tests

  - test: add DeepEval coverage for find-discussions by @mwbrooks in #62
  - test: raise ToolCorrectnessMetric threshold to 0.85 by @WilliamBergamin in #88

  🧹 Chores

  - chore: add slack-skills-plugin-team as default CODEOWNERS team by @mwbrooks in #63
  - chore: add pull request template by @mwbrooks in #69
  - chore: add chore + security labels and align release notes categories by @mwbrooks in #73 ← this PR

  ⬆️ Dependencies

  - chore(deps): bump actions/checkout from 6.0.3 to 7.0.0 by @dependabot in #64
  - chore(deps): bump actions/setup-python from 6.2.0 to 6.3.0 by @dependabot in #67

  🔒 Security

  - fix: patch prompt-injection in canvas rendering pipeline by @mwbrooks in #98
  - chore(deps): bump requests from 2.31.0 to 2.32.4 (CVE-2024-XXXXX) by @dependabot in #99

  📦 Other changes

  (empty when every merged PR carries at least one recognized label — which is the goal)

  Full Changelog: https://github.com/slackapi/slack-mcp-plugin/compare/v0.4.0...v0.5.0
```

### Testing

- This PR itself uses the `chore` label, serving as the first live test of the new label + release-notes category.

### Notes

- No changeset needed - updates to CI/repo metadata don't affect plugin consumers (per `maintainers_guide.md`).

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.