### PR TITLE
ci: announce releases on Slack from the release workflow

### DIFF
--- a/.changeset/announce-releases-on-slack.md
+++ b/.changeset/announce-releases-on-slack.md
@@ -2,4 +2,4 @@
 "slack": patch
 ---
 
-Automate Slack release announcements from the release workflow.
+Automate release announcements to the internal maintainers' Slack channel from the release workflow.

--- a/.changeset/announce-releases-on-slack.md
+++ b/.changeset/announce-releases-on-slack.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Automate Slack release announcements from the release workflow.

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -88,8 +88,7 @@ New official package versions are published when the release PR created from cha
 
 4. **Merge and approve**: Merge the release PR. It may take up to 24 hours before you see you release in the [Claude Plugins](https://claude.com/plugins/slack) directory.
 
-5. **Communicate the release**:
-   - **External**: Post in relevant channels (e.g. #lang-javascript, #tools-bolt) on [Slack Community](https://community.slack.com/). Include a link to the release notes.
+5. **Communicate the release**: A Slack announcement is posted automatically to the release-announcements channel by `.github/workflows/release.yml` when the release PR is merged and a tag is cut. For broader outreach (e.g. `#tools-bolt` on [Slack Community](https://community.slack.com/)), post manually if desired.
 
 ## Everything Else
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install Node dependencies
         run: npm install
       - name: Changesets release
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bash scripts/changeset_version.sh
@@ -47,3 +48,25 @@ jobs:
           prDraft: create
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get publication details
+        id: release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          message=$(echo "$PUBLISHED_PACKAGES" | jq -r 'map("\(.name)@\(.version)") | join(", ")')
+          action_url=$(echo "$PUBLISHED_PACKAGES" | jq -r --arg repo "${{ github.server_url }}/${{ github.repository }}" 'map("\($repo)/releases/tag/\(.name)@\(.version)") | join(", ")')
+          {
+            echo "message=$message"
+            echo "action_url=$action_url"
+          } >> "$GITHUB_OUTPUT"
+      - name: Notify Slack
+        if: steps.changesets.outputs.published == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_ANNOUNCEMENTS_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            action_url: "${{ steps.release.outputs.action_url }}"
+            message: "${{ steps.release.outputs.message }}"
+            repository: "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,11 @@ jobs:
         id: release
         if: steps.changesets.outputs.published == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
-          message=$(echo "$PUBLISHED_PACKAGES" | jq -r 'map("\(.name)@\(.version)") | join(", ")')
-          action_url=$(echo "$PUBLISHED_PACKAGES" | jq -r --arg repo "${{ github.server_url }}/${{ github.repository }}" 'map("\($repo)/releases/tag/\(.name)@\(.version)") | join(", ")')
-          {
-            echo "message=$message"
-            echo "action_url=$action_url"
-          } >> "$GITHUB_OUTPUT"
+          echo "url=$(gh release view --json url -q .url)" >> "$GITHUB_OUTPUT"
+          echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"' | paste -sd ', ' -)" >> "$GITHUB_OUTPUT"
       - name: Notify Slack
         if: steps.changesets.outputs.published == 'true'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -67,6 +64,6 @@ jobs:
           webhook: ${{ secrets.SLACK_RELEASE_ANNOUNCEMENTS_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            action_url: "${{ steps.release.outputs.action_url }}"
+            action_url: "${{ steps.release.outputs.url }}"
             message: "${{ steps.release.outputs.message }}"
             repository: "${{ github.repository }}"


### PR DESCRIPTION
### Summary

This pull request add a release announcement to our internal Slack channel. 📣 

When `changesets/action` reports a package was published, the release action will now resolve the release URL from `publishedPackages` and post to the Slack Workflow Builder trigger via `slackapi/slack-github-action` in `webhook-trigger` mode.

This mirrors the pattern in [`node-slack-sdk/release.yml`](https://github.com/slackapi/node-slack-sdk/blob/12b94a2c21268403c3f216e88232a841cfb47571/.github/workflows/release.yml#L145-L154).

Both new steps gate on `steps.changesets.outputs.published == 'true'`, so nothing fires on the "opens/updates the release PR" runs - only on the run that follows merging that PR and cutting a tag.

Related to #71 (`createGithubReleases: true`), which is what gives the `action_url` link something real to point at.

### Preview

- N/A

### Testing

- **Dry-run plan** after merge: trigger this workflow via `workflow_dispatch` from the Actions UI with no pending changesets - `steps.changesets.outputs.published` will be `'false'` and both new steps must show `skipped`, proving the gate works.
- **End-to-end**: on the next real release (merge of the auto-opened "chore: release" PR), confirm `Get publication details` and `Notify Slack` execute (not skipped), and that the Slack channel receives a message with a working link to `https://github.com/slackapi/slack-mcp-plugin/releases/tag/slack@<version>`.

### Notes

- **Secret:** `SLACK_RELEASE_ANNOUNCEMENTS_WEBHOOK_URL` is configured.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run \`make test\` and the tests pass.