### PR TITLE
chore: rename `Metadata` to `Frontmatter` in test skill model

### DIFF
--- a/tests/skill.py
+++ b/tests/skill.py
@@ -7,7 +7,7 @@ from tests.config import SKILLS_ROOT
 
 
 @dataclasses.dataclass
-class Metadata:
+class Frontmatter:
     #: The skill name extracted from the frontmatter `name` field.
     name: str
 
@@ -22,7 +22,7 @@ class Metadata:
 @dataclasses.dataclass
 class Skill:
     #: Parsed frontmatter fields.
-    metadata: Metadata
+    frontmatter: Frontmatter
 
     #: The markdown content below the frontmatter delimiters.
     body: str
@@ -44,7 +44,7 @@ class Skill:
                 frontmatter = yaml.safe_load(parts[1]) or {}
                 body = parts[2].strip()
         return cls(
-            metadata=Metadata(
+            frontmatter=Frontmatter(
                 name=frontmatter.get("name", ""),
                 description=frontmatter.get("description", ""),
                 argument_hint=frontmatter.get("argument-hint"),

--- a/tests/support/tools.py
+++ b/tests/support/tools.py
@@ -11,7 +11,9 @@ __all__ = ["get_all_skill_tools", "get_slack_mcp_tools"]
 
 def get_all_skill_tools() -> list[ToolCall]:
     """Convert every discovered plugin skill into a `ToolCall`."""
-    return [ToolCall(name=skill.metadata.name, description=skill.metadata.description) for skill in discover_skills()]
+    return [
+        ToolCall(name=skill.frontmatter.name, description=skill.frontmatter.description) for skill in discover_skills()
+    ]
 
 
 def get_slack_mcp_tools() -> list[ToolCall]:

--- a/tests/unit/test_cross_skill_references.py
+++ b/tests/unit/test_cross_skill_references.py
@@ -7,15 +7,13 @@ from tests.skill import discover_skills
 class TestCrossSkillReferences:
     def setup_method(self):
         self.skills = discover_skills()
-        self.skill_names = {skill.metadata.name for skill in self.skills}
+        self.skill_names = {skill.frontmatter.name for skill in self.skills}
 
     def test_plugin_skill_references_target_real_skills(self):
         pattern = re.compile(rf"`{re.escape(PLUGIN_NAME)}:([a-z0-9-]+)`")
         for skill in self.skills:
             for target in pattern.findall(skill.body):
-                assert (
-                    target in self.skill_names
-                ), f"{skill.path} references unknown skill `{PLUGIN_NAME}:{target}`"
+                assert target in self.skill_names, f"{skill.path} references unknown skill `{PLUGIN_NAME}:{target}`"
 
     def test_no_markdown_anchor_links(self):
         for skill in self.skills:

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -10,6 +10,6 @@ class TestSkillDiscovery:
         assert len(self.skills) > 0, "No skills found"
 
     def test_expected_skills_exist(self):
-        found = [s.metadata.name for s in self.skills]
+        found = [s.frontmatter.name for s in self.skills]
         for expected in EXPECTED_SKILLS:
             assert expected in found

--- a/tests/unit/test_frontmatter.py
+++ b/tests/unit/test_frontmatter.py
@@ -9,17 +9,17 @@ class TestFrontmatter:
 
     def test_required_fields_present(self):
         for skill in self.skills:
-            assert skill.metadata.name
-            assert skill.metadata.description
+            assert skill.frontmatter.name
+            assert skill.frontmatter.description
 
     def test_name_matches_directory(self):
         for skill in self.skills:
-            assert skill.metadata.name == skill.path.parent.name
+            assert skill.frontmatter.name == skill.path.parent.name
 
     def test_name_is_kebab_case(self):
         for skill in self.skills:
-            assert re.search(r"^[a-z][a-z0-9-]*$", skill.metadata.name)
+            assert re.search(r"^[a-z][a-z0-9-]*$", skill.frontmatter.name)
 
     def test_description_is_meaningful(self):
         for skill in self.skills:
-            assert len(skill.metadata.description) > 20
+            assert len(skill.frontmatter.description) > 20


### PR DESCRIPTION
## Summary

Renames the `Metadata` dataclass to `Frontmatter` in the test skill model. This makes the terminology consistent with what the data actually is.

Pure rename, no behavior change.

## Changes

- `tests/skill.py` — `class Metadata` → `class Frontmatter`; `Skill.metadata: Metadata` → `Skill.frontmatter: Frontmatter`; constructor call updated.
- Consumers updated to `skill.frontmatter.*`: `tests/support/tools.py`, `tests/unit/test_frontmatter.py`, `tests/unit/test_discovery.py`, `tests/unit/test_cross_skill_references.py`.

## Testing

- `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)