### PR TITLE
docs: add local development and testing to maintainer's guide

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -44,6 +44,85 @@ source .venv/bin/activate
 
 ---
 
+## Local Development & Testing
+
+Before you release (or open a PR), exercise your changes locally: run the test
+suite, and load the plugin into Claude Code or Cursor to try the skills and
+commands by hand.
+
+### Setup
+
+Run the one-time setup, which creates the virtualenv, installs the test and lint
+dependencies, and downloads a project-local Ollama instance plus the `gemma4`
+judge model used by the eval tests (requires Python 3.14+, see above):
+
+```sh
+make install
+```
+
+The LLM-judged tests read two environment variables. Copy the example file and
+fill in what you need — the `Makefile` auto-loads `.env`:
+
+```sh
+cp .env.example .env
+```
+
+- `OLLAMA_MODEL_NAME` — the DeepEval judge model. Defaults to `gemma4`.
+- `SLACK_MCP_TOKEN` — a Slack MCP bearer token, needed only for the MCP
+  tool-selection eval test. That test is skipped when it's unset.
+
+### Running the tests
+
+Always use the `make` targets — never invoke `pytest`, `ruff`, or `python`
+directly. The targets manage the virtualenv, load `.env`, and start and stop the
+local Ollama instance for you.
+
+```sh
+make test-unit   # fast structural + frontmatter checks (this is what CI runs)
+make test-eval   # LLM-judged DeepEval tests; starts and stops Ollama (local only)
+make test        # both
+make lint        # Ruff linter (line-length 120)
+make format      # Ruff auto-format + fix
+```
+
+Unit tests run on every PR in CI; the eval tests do not (downloading Ollama and
+the model would blow the CI time budget), so run `make test-eval` yourself before
+a release.
+
+### Testing in Claude Code
+
+Load your working checkout into Claude Code for a single session with the
+`--plugin-dir` flag:
+
+```sh
+claude --plugin-dir ./
+```
+
+This loads the `slack` plugin from your checkout — all six skills, five commands,
+and the HTTP MCP server from `.mcp.json`. If you already have the published
+`slack` plugin installed, the local copy takes precedence **for that session
+only**: nothing is written to your settings, and the installed version is
+untouched when you exit. After editing a skill or command, run `/reload-plugins`
+inside the session to pick up the change without restarting.
+
+To check the plugin's structure without launching a session, run `claude plugin
+validate`.
+
+### Testing in Cursor
+
+Install the plugin into your local Cursor, then reload plugins in Cursor to pick
+up the changes:
+
+```sh
+make cursor-install
+```
+
+This copies the plugin into `~/.cursor/plugins/slack@local` and registers it. To
+remove it, run `make cursor-uninstall`. (`make clean` also runs the Cursor
+uninstall, in addition to removing `.venv`, `.ollama`, and `node_modules`.)
+
+---
+
 ## Versioning
 
 Follow the [conventional commit specification][conv-commits]. PR titles and commit messages use prefixes like `feat:`, `fix:`, `chore:`, `docs:`, etc. First letter after the prefix is lowercase unless it's a proper noun.
@@ -80,7 +159,7 @@ Releasing can feel intimidating at first, but don't fret! Venture on!
 
 New official package versions are published when the release PR created from changesets is merged. Follow these steps to build confidence:
 
-1. **Run the tests locally**: Before merging the release PR please run all the tests especially the eval ones. If they no longer pass we may need fix it before releasing the changes.
+1. **Run the tests locally**: Before merging the release PR please run all the tests (see [Local Development & Testing](#local-development--testing)), especially the eval ones. If they no longer pass we may need fix it before releasing the changes.
 
 2. **Check GitHub**: Please check if issues or pull requests are still open either decide to postpone the release or save those changes for a future update.
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -65,6 +65,8 @@ and fill in what you need — each variable is documented inline, and the
 
 ```sh
 cp .env.example .env
+vim .env
+# Set the environment variables
 ```
 
 ### Running the tests
@@ -81,20 +83,17 @@ make lint        # Ruff linter (line-length 120)
 make format      # Ruff auto-format + fix
 ```
 
-Unit tests run on every PR in CI; the eval tests do not (they would blow the CI
-time budget), so run `make test-eval` yourself before a release.
-
 ### Testing in Claude Code
 
-Load your working checkout into Claude Code for a single session with the
+Load your local changes into Claude Code for a single session with the
 `--plugin-dir` flag:
 
 ```sh
 claude --plugin-dir ./
 ```
 
-This loads the `slack` plugin from your checkout — all six skills, five commands,
-and the HTTP MCP server from `.mcp.json`. If you already have the published
+This loads the `slack` plugin from your checkout — its skills and commands, and
+the HTTP MCP server from `.mcp.json`. If you already have the published
 `slack` plugin installed, the local copy takes precedence **for that session
 only**: nothing is written to your settings, and the installed version is
 untouched when you exit. After editing a skill or command, run `/reload-plugins`
@@ -112,8 +111,9 @@ up the changes:
 make cursor-install
 ```
 
-This copies the plugin into `~/.cursor/plugins/slack@local` and registers it. To
-remove it, run `make cursor-uninstall`. (`make clean` also runs the Cursor
+This copies the plugin into `~/.cursor/plugins/slack@local` and registers it.
+
+To remove it, run `make cursor-uninstall`. (`make clean` also runs the Cursor
 uninstall, in addition to removing the virtualenv and other generated files.)
 
 ---

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -13,6 +13,8 @@ Maintaining this repo requires:
 - **[Claude Code][claude-code]**: the primary development and maintenance tool.
   Most tasks (authoring skills, reviewing diffs) are performed through Claude
   Code rather than traditional CLI tooling.
+- **[Cursor][cursor]**: an alternative agentic coding environment. Useful for
+  verifying that skills and commands work outside Claude Code before release.
 - **Git**: standard version control.
 - **[GitHub CLI (`gh`)][gh-cli]**: for creating PRs as drafts and managing
   issues.
@@ -200,6 +202,7 @@ Patch and minor updates are auto-approved and auto-merged via the
 ---
 
 [claude-code]: https://claude.ai/code
+[cursor]: https://cursor.com
 [gh-cli]: https://cli.github.com
 [conv-commits]: https://www.conventionalcommits.org
 [semver]: https://semver.org

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -59,34 +59,30 @@ lint dependencies (requires Python 3.14+, see above):
 make install
 ```
 
-The LLM-judged tests read two environment variables. Copy the example file and
-fill in what you need — the `Makefile` auto-loads `.env`:
+The tests read configuration from environment variables. Copy the example file
+and fill in what you need — each variable is documented inline, and the
+`Makefile` auto-loads `.env`:
 
 ```sh
 cp .env.example .env
 ```
 
-- `OLLAMA_MODEL_NAME` — the DeepEval judge model. Defaults to `gemma4`.
-- `SLACK_MCP_TOKEN` — a Slack MCP bearer token, needed only for the MCP
-  tool-selection eval test. That test is skipped when it's unset.
-
 ### Running the tests
 
 Always use the `make` targets — never invoke `pytest`, `ruff`, or `python`
-directly. The targets manage the virtualenv, load `.env`, and start and stop the
-local Ollama instance for you.
+directly. The targets manage the virtualenv, load `.env`, and set up the test
+dependencies for you.
 
 ```sh
 make test-unit   # fast structural + frontmatter checks (this is what CI runs)
-make test-eval   # LLM-judged DeepEval tests; starts and stops Ollama (local only)
+make test-eval   # LLM-judged skill evaluations (local only)
 make test        # both
 make lint        # Ruff linter (line-length 120)
 make format      # Ruff auto-format + fix
 ```
 
-Unit tests run on every PR in CI; the eval tests do not (downloading Ollama and
-the model would blow the CI time budget), so run `make test-eval` yourself before
-a release.
+Unit tests run on every PR in CI; the eval tests do not (they would blow the CI
+time budget), so run `make test-eval` yourself before a release.
 
 ### Testing in Claude Code
 
@@ -118,7 +114,7 @@ make cursor-install
 
 This copies the plugin into `~/.cursor/plugins/slack@local` and registers it. To
 remove it, run `make cursor-uninstall`. (`make clean` also runs the Cursor
-uninstall, in addition to removing `.venv`, `.ollama`, and `node_modules`.)
+uninstall, in addition to removing the virtualenv and other generated files.)
 
 ---
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -52,9 +52,8 @@ commands by hand.
 
 ### Setup
 
-Run the one-time setup, which creates the virtualenv, installs the test and lint
-dependencies, and downloads a project-local Ollama instance plus the `gemma4`
-judge model used by the eval tests (requires Python 3.14+, see above):
+Run the one-time setup, which creates the virtualenv and installs the test and
+lint dependencies (requires Python 3.14+, see above):
 
 ```sh
 make install

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -99,8 +99,11 @@ only**: nothing is written to your settings, and the installed version is
 untouched when you exit. After editing a skill or command, run `/reload-plugins`
 inside the session to pick up the change without restarting.
 
-To check the plugin's structure without launching a session, run `claude plugin
-validate`.
+Check the plugin's structure without launching a session:
+
+```sh
+claude plugin validate
+```
 
 ### Testing in Cursor
 


### PR DESCRIPTION
### Summary

This pull request adds a **Local Development & Testing** section to the maintainer's guide.

It documents:
- **Setup** - `make install` and the `.env` vars (`OLLAMA_MODEL_NAME`, `SLACK_MCP_TOKEN`).
- **Running the tests** - the `make test-unit` / `test-eval` / `test` / `lint` / `format` targets.
- **Testing in Claude Code** - `claude --plugin-dir ./` loads the local plugin for one session and takes precedence over an installed `slack` plugin; `/reload-plugins` picks up edits.
- **Testing in Cursor** - `make cursor-install` / `cursor-uninstall`.

### Preview

_N/A - documentation only._


### Notes

- Docs-only; no changeset.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.