### PR TITLE
test: fix eval tests to use renamed frontmatter attribute

### DIFF
--- a/tests/eval/skills/test_block_kit.py
+++ b/tests/eval/skills/test_block_kit.py
@@ -16,14 +16,14 @@ class TestBlockKit:
 
     def test_skill_is_usable(self):
         skill_tool = ToolCall(
-            name=self.skill.metadata.name,
-            description=self.skill.metadata.description,
+            name=self.skill.frontmatter.name,
+            description=self.skill.frontmatter.description,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )
 
         expected_tool = ToolCall(
-            name=self.skill.metadata.name,
+            name=self.skill.frontmatter.name,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )

--- a/tests/eval/skills/test_create_slack_app.py
+++ b/tests/eval/skills/test_create_slack_app.py
@@ -16,14 +16,14 @@ class TestCreateSlackApp:
 
     def test_skill_is_usable(self):
         skill_tool = ToolCall(
-            name=self.skill.metadata.name,
-            description=self.skill.metadata.description,
+            name=self.skill.frontmatter.name,
+            description=self.skill.frontmatter.description,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )
 
         expected_tool = ToolCall(
-            name=self.skill.metadata.name,
+            name=self.skill.frontmatter.name,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )

--- a/tests/eval/skills/test_slack_api.py
+++ b/tests/eval/skills/test_slack_api.py
@@ -16,14 +16,14 @@ class TestSlackApi:
 
     def test_skill_is_usable(self):
         skill_tool = ToolCall(
-            name=self.skill.metadata.name,
-            description=self.skill.metadata.description,
+            name=self.skill.frontmatter.name,
+            description=self.skill.frontmatter.description,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )
 
         expected_tool = ToolCall(
-            name=self.skill.metadata.name,
+            name=self.skill.frontmatter.name,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )

--- a/tests/eval/skills/test_slack_cli.py
+++ b/tests/eval/skills/test_slack_cli.py
@@ -16,14 +16,14 @@ class TestSlackCli:
 
     def test_skill_is_usable(self):
         skill_tool = ToolCall(
-            name=self.skill.metadata.name,
-            description=self.skill.metadata.description,
+            name=self.skill.frontmatter.name,
+            description=self.skill.frontmatter.description,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )
 
         expected_tool = ToolCall(
-            name=self.skill.metadata.name,
+            name=self.skill.frontmatter.name,
             input_parameters={"request": PROMPT},
             output=self.skill.body,
         )


### PR DESCRIPTION
### Summary

Fixes test failures on `make test-eval` due to some tests still referencing `self.skill.metadata.

- The `Metadata` → `Frontmatter` rename in #76 updated the `Skill` dataclass but some eval tests still reference `self.skill.metadata`.
- This causes an `AttributeError` on every `make test-eval` run, making all skill eval tests fail immediately.
- Renames `.metadata.` → `.frontmatter.` in all four `tests/eval/skills/test_*.py` files.

### Preview

_N/A - test-only change._

### Testing

- `make test-unit` → 12 passed (unaffected).
- `make test-eval testdir=tests/eval/skills/` → all four skill eval tests pass; no more `AttributeError`.

### Notes

- Test-only change, so no changeset (per the maintainer's guide, "updates to documentation, tests, or CI might not require new entries").
- No CI impact: CI runs only `make lint` and `make test-unit`; the eval tests are local-only.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.