### PR TITLE
test: improve the stability of .env sourcing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This plugin integrates Slack with Ai tools, providing tools to search, read, and
 
 Requires Python 3.14+. Run `make install` before first use to set up the virtual environment and test dependencies.
 
-**Always use the `make` targets — never invoke `python`, `pytest`, or `ruff` directly.** The targets manage the virtualenv and load `.env` for you; running the underlying tools by hand skips that setup and will behave differently. If a `make` command is broken or missing something you need, fix the `Makefile` rather than working around it with the raw command.
+**Always use the `make` targets — never invoke `python`, `pytest`, or `ruff` directly.** The targets manage the virtualenv for you; running the underlying tools by hand skips that setup and will behave differently. (The test suite loads `.env` itself, so env vars are available either way — see below.) If a `make` command is broken or missing something you need, fix the `Makefile` rather than working around it with the raw command.
 
 | Command | Purpose |
 |---------|---------|
@@ -28,7 +28,7 @@ Requires Python 3.14+. Run `make install` before first use to set up the virtual
 | `make cursor-install` | Install this plugin into a local Cursor for development |
 | `make cursor-uninstall` | Uninstall this plugin from the local Cursor install |
 
-The LLM tests read `GEMINI_API_KEY` (required — the eval suite fails when it's unset) and `SLACK_MCP_TOKEN` (a Slack MCP bearer token; the MCP tool-selection test is skipped when it's unset). The DeepEval judge model defaults to `gemini-3.1-flash-lite`, overridable via `GEMINI_MODEL_NAME`. Copy `.env.example` to `.env` and fill in values — the `Makefile` auto-loads `.env` — or pass them inline, e.g. `GEMINI_MODEL_NAME=<model> make test-eval`.
+The LLM tests read `GEMINI_API_KEY` (required — the eval suite fails when it's unset) and `SLACK_MCP_TOKEN` (a Slack MCP bearer token; the MCP tool-selection test is skipped when it's unset). The DeepEval judge model defaults to `gemini-3.1-flash-lite`, overridable via `GEMINI_MODEL_NAME`. Copy `.env.example` to `.env` and fill in values — the test suite loads `.env` from the repo root via `python-dotenv` (`tests/config.py`), so values load the same however tests are launched. Real environment variables take precedence over `.env`, so you can also override inline, e.g. `GEMINI_MODEL_NAME=<model> make test-eval`.
 
 ## Cross-Skill References
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,6 @@ PIP := $(VENV)/bin/pip
 RUFF := $(VENV)/bin/ruff
 DEEPEVAL := $(VENV)/bin/deepeval
 
-# Load .env if present (see .env.example) and export its vars to recipe
-# subprocesses. The leading `-` no-ops when .env is absent; bare `export` only
-# exports *defined* vars, so a missing .env never shadows the in-code defaults.
--include .env
-export
-
 TARGETS := help install install-test install-tools clean lint format test test-unit test-eval cursor-install cursor-uninstall
 
 .PHONY: $(TARGETS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ test = [
     # (used by `make test-eval`) crashes on import. Exclude that one release.
     "deepeval>=4.0,<5.0,!=4.0.6",
     "google-genai>=1.0,<2.0",
+    "python-dotenv>=1.0,<2.0",
     "pyyaml>=6.0,<7.0",
     "mcp>=1.13,<2.0",
 ]

--- a/tests/config.py
+++ b/tests/config.py
@@ -2,6 +2,11 @@ import json
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+# Load .env from the repo root (if present) before reading the environment
+load_dotenv(Path(__file__).parent.parent / ".env")
+
 # Filesystem
 SKILLS_ROOT = Path(__file__).parent.parent / "skills"
 


### PR DESCRIPTION
### Summary

`.env` loading was inconsistent. The root cause is **how the `Makefile` loaded `.env`**:

```make
-include .env
export
```

`-include` makes **GNU Make parse `.env` as Makefile syntax, not dotenv syntax**, so values are mangled depending on which characters they contain:

- `GEMINI_API_KEY=abc$def` → Make expands `$d` as an (empty) Make variable, so the value silently becomes `abcef`.
- A `#` anywhere in a value truncates it (Make treats it as a comment), and surrounding quotes are kept literally.

**Fix:** load `.env` in `tests/config.py` using `python-dotenv`. Values now load identically regardless of characters or how the tests are launched.

### Preview

N/A — no user-facing UI changes.

### Testing

- `make lint` — passes.
- `make test-unit` — 12/12 pass.
- With an adversarial `.env` (`GEMINI_API_KEY=abc$def#x`), confirmed `tests.config.GEMINI_API_KEY` loads as the exact literal `'abc$def#x'` (previously corrupted by Make).
- Confirmed precedence: `GEMINI_MODEL_NAME=from-cli` in the process env still wins over the `.env` value.
- Confirmed a missing `.env` is a no-op — import succeeds with empty/default values.

### Notes

N/A

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass. (Ran `make lint` + `make test-unit`; did not run `make test-eval`, which needs a live `GEMINI_API_KEY`.)
