### PR TITLE
build: add rumdl Markdown linter and fix markdown formatting

### DIFF
--- a/.changeset/add-rumdl-markdown-linter.md
+++ b/.changeset/add-rumdl-markdown-linter.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Add rumdl Markdown linting to `make lint`/`make format` and clean up formatting across the skill and command docs.

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -81,10 +81,16 @@ dependencies for you.
 make test-unit   # fast structural + frontmatter checks (this is what CI runs)
 make test-eval   # LLM-judged skill evaluations (local only)
 make test        # both
-make lint        # Ruff linter (line-length 120)
-make format      # Ruff auto-format + fix
+make lint        # Ruff (Python) + rumdl (Markdown) linter checks
+make format      # Auto-format: Ruff for Python, rumdl --fix for Markdown
 make typecheck   # Mypy static type checks
 ```
+
+Markdown linting is powered by [rumdl](https://github.com/rvben/rumdl), a
+markdownlint-compatible Rust linter. It validates `skills/`, `commands/`,
+`README.md`, and `AGENTS.md`. Rules and disabled checks are configured under
+`[tool.rumdl]` in `pyproject.toml` — tune that section when a new skill trips a
+rule that isn't worth enforcing.
 
 ### Testing in Claude Code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Requires Python 3.14+. Run `make install` before first use to set up the virtual
 | Command | Purpose |
 |---------|---------|
 | `make install` | Full setup: venv + deps |
-| `make lint` | Ruff linter (line-length=120) |
-| `make format` | Ruff auto-format + fix |
+| `make lint` | Ruff (Python) + rumdl (Markdown) linter checks |
+| `make format` | Auto-format: Ruff for Python, rumdl --fix for Markdown |
 | `make typecheck` | Mypy static type checks |
 | `make test-unit` | Fast validation tests (pytest) |
 | `make test-eval` | LLM-judged tests (runs DeepEval against Gemini) |

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VENV := .venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 RUFF := $(VENV)/bin/ruff
+RUMDL := $(VENV)/bin/rumdl
 MYPY := $(VENV)/bin/mypy
 DEEPEVAL := $(VENV)/bin/deepeval
 
@@ -36,12 +37,14 @@ cursor-install: $(VENV) ## Install this plugin into a local Cursor for developme
 cursor-uninstall: $(VENV) ## Uninstall this plugin from the local Cursor install
 	$(PYTHON) scripts/cursor.py uninstall
 
-lint: ## Run ruff linter checks
+lint: ## Run linter checks (ruff for Python, rumdl for Markdown)
 	$(RUFF) check .
+	$(RUMDL) check .
 
-format: ## Auto-format code with ruff
+format: ## Auto-format code (ruff for Python, rumdl for Markdown)
 	$(RUFF) format .
 	$(RUFF) check --fix .
+	$(RUMDL) check --fix .
 
 typecheck: ## Run mypy static type checks
 	$(MYPY)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [Claude Code][claude-code] and [Cursor][cursor] plugin that brings Slack into 
 
 The plugin is published on the [official Claude marketplace](https://claude.com/plugins/slack). Install it from inside Claude Code:
 
-```
+```text
 /plugin install slack@claude-plugins-official
 ```
 

--- a/commands/channel-digest.md
+++ b/commands/channel-digest.md
@@ -13,7 +13,7 @@ Given the comma-separated channel names provided in $ARGUMENTS (strip leading `#
 
 3. Present the digest in this format:
 
-   ```
+   ```text
    **Channel Digest — <today's date>**
 
    **#channel-1**

--- a/commands/standup.md
+++ b/commands/standup.md
@@ -14,7 +14,8 @@ description: Generate a standup update based on your recent Slack activity
 4. For messages in threads, use `slack_read_thread` to get the full context so you can accurately describe what the user contributed.
 
 5. Format the standup as:
-   ```
+
+   ```text
    **Standup for <display name> — <today's date>**
 
    **Done:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ test = [
     "pyyaml>=6.0,<7.0",
     "mcp>=1.13,<2.0",
 ]
-tools = ["ruff>=0.11,<1.0", "mypy>=1.11,<2.0", "types-PyYAML>=6.0,<7.0"]
+tools = ["ruff>=0.11,<1.0", "rumdl>=0.2,<1.0", "mypy>=1.11,<2.0", "types-PyYAML>=6.0,<7.0"]
 
 # This project is installed only to run the test suite; the importable package
 # is `tests`. Scope discovery to it so setuptools' flat-layout autodiscovery
@@ -39,6 +39,18 @@ known-first-party = ["tests"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+# rumdl: markdownlint-compatible linter for the plugin's authored markdown.
+[tool.rumdl]
+include = ["skills/**/*.md", "commands/*.md", "README.md", "AGENTS.md"]
+exclude = [".venv", "node_modules", ".changeset"]
+respect-gitignore = true
+# Disable rules that conflict with the skill-authoring style:
+#   MD013 — prose lines are intentionally long (LLM-consumed, not reflowed)
+#   MD028 — blank lines inside blockquotes are intentional for readability
+#   MD036 — emphasis is used for styled numbered steps, not headings
+#   MD041 — commands use frontmatter before the first heading; skills validated by pytest
+disable = ["MD013", "MD028", "MD036", "MD041"]
 
 [tool.mypy]
 python_version = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,12 @@ test = [
     "pyyaml>=6.0,<7.0",
     "mcp>=1.13,<2.0",
 ]
-tools = ["ruff>=0.11,<1.0", "rumdl>=0.2,<1.0", "mypy>=1.11,<2.0", "types-PyYAML>=6.0,<7.0"]
+tools = [
+    "ruff>=0.11,<1.0",
+    "rumdl>=0.2,<1.0",
+    "mypy>=1.11,<2.0",
+    "types-PyYAML>=6.0,<7.0",
+]
 
 # This project is installed only to run the test suite; the importable package
 # is `tests`. Scope discovery to it so setuptools' flat-layout autodiscovery
@@ -51,6 +56,13 @@ respect-gitignore = true
 #   MD036 — emphasis is used for styled numbered steps, not headings
 #   MD041 — commands use frontmatter before the first heading; skills validated by pytest
 disable = ["MD013", "MD028", "MD036", "MD041"]
+
+# Emphasis markers: italics use _underscores_, bold uses **asterisks**.
+[tool.rumdl.MD049]
+style = "underscore"
+
+[tool.rumdl.MD050]
+style = "asterisk"
 
 [tool.mypy]
 python_version = "3.14"

--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -13,7 +13,7 @@ This skill walks through surface selection, layout planning, JSON generation, an
 > **Common Block Kit mistakes (and why):** A few errors recur often enough to flag up front. Most others are caught by `blocks.validate` in Step 5, so lean on validation rather than memorizing rules.
 >
 > - **`"type": "text"` is not a thing.** Text is a composition object: `{ "type": "plain_text", "text": "..." }` or `{ "type": "mrkdwn", "text": "..." }`.
-> - **`markdown` is a _block_ type, not a text type.** A `markdown` block holds standard markdown; text objects inside other blocks use `mrkdwn` (see **mrkdwn vs. the `markdown` block** in Step 4). Slack's `mrkdwn` is `*bold*` / `_italic_` / `~strike~`, not `**bold**`.
+> - **`markdown` is a *block* type, not a text type.** A `markdown` block holds standard markdown; text objects inside other blocks use `mrkdwn` (see **mrkdwn vs. the `markdown` block** in Step 4). Slack's `mrkdwn` is `*bold*` / `_italic_` / `~strike~`, not `**bold**`.
 > - **Messages need a top-level `text` fallback.** `blocks.validate` won't flag a missing one, but notifications and screen readers display it instead of the blocks — so summarize what the layout conveys rather than leaving it empty.
 
 ---
@@ -127,13 +127,15 @@ Based on the developer's description:
    - Check `references/common-patterns.md` (the one local reference file) if the request matches a common pattern; start from the template instead of building from scratch.
    - Defer reading individual component pages until Step 4, when you build each block's fields.
 2. Propose a numbered block outline. For example:
-   ```
+
+   ```text
    1. header: "Weekly Report"
    2. section: Summary text with a datepicker accessory
    3. divider
    4. section: Status fields (Name, Role, Team)
    5. actions: "Approve" button (primary) and "Reject" button (danger)
    ```
+
 3. Present the outline to the developer and ask for approval or changes before generating JSON.
 
 **Surface constraints to check:**

--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -13,7 +13,7 @@ This skill walks through surface selection, layout planning, JSON generation, an
 > **Common Block Kit mistakes (and why):** A few errors recur often enough to flag up front. Most others are caught by `blocks.validate` in Step 5, so lean on validation rather than memorizing rules.
 >
 > - **`"type": "text"` is not a thing.** Text is a composition object: `{ "type": "plain_text", "text": "..." }` or `{ "type": "mrkdwn", "text": "..." }`.
-> - **`markdown` is a *block* type, not a text type.** A `markdown` block holds standard markdown; text objects inside other blocks use `mrkdwn` (see **mrkdwn vs. the `markdown` block** in Step 4). Slack's `mrkdwn` is `*bold*` / `_italic_` / `~strike~`, not `**bold**`.
+> - **`markdown` is a _block_ type, not a text type.** A `markdown` block holds standard markdown; text objects inside other blocks use `mrkdwn` (see **mrkdwn vs. the `markdown` block** in Step 4). Slack's `mrkdwn` is `*bold*` / `_italic_` / `~strike~`, not `**bold**`.
 > - **Messages need a top-level `text` fallback.** `blocks.validate` won't flag a missing one, but notifications and screen readers display it instead of the blocks — so summarize what the layout conveys rather than leaving it empty.
 
 ---
@@ -158,7 +158,7 @@ Once the layout is approved, build each block from its live doc page, fetching e
 - For modals, include `title`, `submit`, `close`, and `callback_id`; for home tabs, the `type: "home"` wrapper
 - Use `mrkdwn` text for rich formatting, `plain_text` where required (headers, labels, modal title)
 
-**mrkdwn vs. the `markdown` block:** `section` and `context` blocks format text with Slack's `mrkdwn` (`*bold*`, `_italic_`, `~strike~`, `` `code` ``) — use these for short, interactive layouts. The separate `markdown` block (Messages only) renders *standard* markdown (`**bold**`, headings, tables, numbered lists) and is meant for AI/LLM-generated or long-form content that already exists in standard markdown. Reach for it when the developer has such content or needs those features in the message body; there is a cumulative 12,000-character limit across all `markdown` blocks in one message.
+**mrkdwn vs. the `markdown` block:** `section` and `context` blocks format text with Slack's `mrkdwn` (`*bold*`, `_italic_`, `~strike~`, `` `code` ``) — use these for short, interactive layouts. The separate `markdown` block (Messages only) renders _standard_ markdown (`**bold**`, headings, tables, numbered lists) and is meant for AI/LLM-generated or long-form content that already exists in standard markdown. Reach for it when the developer has such content or needs those features in the message body; there is a cumulative 12,000-character limit across all `markdown` blocks in one message.
 
 **Accessibility** is easy to skip and hard to retrofit, so build it in now:
 

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -26,8 +26,8 @@ Run `SLACK_CMD version` and print the version to confirm everything is working b
 
 ### 1c. Check language runtime
 
-- **If `$0` is `bolt-js`**: Run `node --version` to verify Node.js is installed (v18+ required). If not installed, suggest `brew install node` or point to https://nodejs.org.
-- **If `$0` is `bolt-python`**: Run `python3 --version` to verify Python is installed (3.6+ required). If not installed, suggest `brew install python3` or point to https://python.org.
+- **If `$0` is `bolt-js`**: Run `node --version` to verify Node.js is installed (v18+ required). If not installed, suggest `brew install node` or point to <https://nodejs.org>.
+- **If `$0` is `bolt-python`**: Run `python3 --version` to verify Python is installed (3.6+ required). If not installed, suggest `brew install python3` or point to <https://python.org>.
 
 ---
 
@@ -45,10 +45,12 @@ Run `SLACK_CMD sandbox list --experiment=sandboxes` to check if the developer al
 
 - **If a sandbox exists**: Show it and confirm they want to use it.
 - **If no sandbox exists**: Tell the developer to create one:
-  ```
+
+  ```text
   ! SLACK_CMD sandbox create --experiment=sandboxes
   ```
-  Alternatively, they can create one at https://api.slack.com/developer-program/sandboxes or join the Developer Program at https://api.slack.com/developer-program/join.
+
+  Alternatively, they can create one at <https://api.slack.com/developer-program/sandboxes> or join the Developer Program at <https://api.slack.com/developer-program/join>.
 
 Wait for confirmation that a sandbox is available before proceeding.
 
@@ -59,6 +61,7 @@ Wait for confirmation that a sandbox is available before proceeding.
 Ask the developer what kind of app they want to build. Present the available templates based on their chosen framework (`$0`):
 
 ### bolt-js templates
+
 | Template | Repo | Description |
 |----------|------|-------------|
 | Starter Template | `slack-samples/bolt-js-starter-template` | Basic Bolt JS app — great starting point |
@@ -68,6 +71,7 @@ Ask the developer what kind of app they want to build. Present the available tem
 | Examples | `slack-samples/bolt-js-examples` | Unified showcase of Slack features |
 
 ### bolt-python templates
+
 | Template | Repo | Description |
 |----------|------|-------------|
 | Starter Template | `slack-samples/bolt-python-starter-template` | Basic Bolt Python app — great starting point |
@@ -83,12 +87,14 @@ Use AskUserQuestion to let the developer pick a template. Recommend the **Starte
 If the developer picks **Starter Agent** or **Support Agent**, these templates contain subdirectories for different AI providers. Ask the developer which provider they want to use via AskUserQuestion:
 
 **bolt-js subdirectories:**
+
 | Subdir | Description |
 |--------|-------------|
 | `claude-agent-sdk` | Uses Anthropic's Claude Agent SDK |
 | `openai-agents-sdk` | Uses OpenAI's Agents SDK |
 
 **bolt-python subdirectories:**
+
 | Subdir | Description |
 |--------|-------------|
 | `claude-agent-sdk` | Uses Anthropic's Claude Agent SDK |
@@ -102,16 +108,19 @@ Recommend **Claude Agent SDK** as the default option.
 Ask what they want to name their project (suggest a default like `my-slack-app`), then run:
 
 **For templates WITHOUT subdirectories** (Starter Template, Getting Started, Assistant Template, Examples):
+
 ```bash
 SLACK_CMD create <project-name> -t <template-repo>
 ```
 
 **For agent templates WITH subdirectories** (Starter Agent, Support Agent):
+
 ```bash
 SLACK_CMD create <project-name> -t <template-repo> --subdir <chosen-subdir>
 ```
 
 For example:
+
 ```bash
 # Non-agent template
 SLACK_CMD create my-slack-app -t slack-samples/bolt-js-starter-template
@@ -141,6 +150,7 @@ cd <project-name> && SLACK_CMD env set <ENV_VAR_NAME> <value>
 ```
 
 For example:
+
 ```bash
 cd my-slack-agent && SLACK_CMD env set ANTHROPIC_API_KEY sk-ant-...
 ```
@@ -164,7 +174,7 @@ After the app is running, suggest next steps:
 1. **Explore the code**: Read through the project files together — offer to explain the app structure, manifest, listeners, etc.
 2. **Make a change**: Suggest a small modification (like changing a message response) to see hot-reload in action.
 3. **Add features**: Based on the template, suggest relevant Slack features to add (slash commands, events, modals, AI capabilities, etc.).
-4. **Check the docs**: Point to https://docs.slack.dev for the full Slack Platform documentation.
+4. **Check the docs**: Point to <https://docs.slack.dev> for the full Slack Platform documentation.
 
 ---
 
@@ -174,4 +184,3 @@ After the app is running, suggest next steps:
 - This skill focuses on **Bolt for JavaScript** and **Bolt for Python** only. Do not suggest Deno, workflow apps, or `slack deploy` (hosted deployment).
 - `SLACK_CMD sandbox create` is an interactive command that requires user input — it does NOT work with the `! command` prefix in Claude Code. Instead, tell the developer to run it in a **new terminal window**.
 - If the developer hits issues, suggest `SLACK_CMD doctor` to diagnose their setup.
-

--- a/skills/slack-api/SKILL.md
+++ b/skills/slack-api/SKILL.md
@@ -53,7 +53,7 @@ Map the developer's intent to a family, then to a candidate method.
 
 WebFetch the live method index:
 
-```
+```text
 https://docs.slack.dev/reference/methods.md
 ```
 
@@ -71,7 +71,7 @@ When you would rather search by keyword than scan the index, and the Slack CLI i
 
 Fetch the method's doc page with WebFetch. Either follow the method's link from the index (Step 1) or construct the URL — the path segment is **all-lowercase** and ends in `.md`:
 
-```
+```text
 https://docs.slack.dev/reference/methods/<method-lowercased>.md
 ```
 

--- a/skills/slack-cli/SKILL.md
+++ b/skills/slack-cli/SKILL.md
@@ -55,9 +55,11 @@ If 1b fails or returns a different value, ask the developer using AskUserQuestio
 - Options: "Yes, it's aliased as..." (let them provide the alias), "No, I need to install it"
 - If they provide an alias, verify it with `<alias> _fingerprint 2>/dev/null` and set `SLACK_CMD=<alias>`.
 - If they need to install it, run:
-  ```
+
+  ```text
   curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash
   ```
+
   Then re-run **1a** — the install script will have written `~/.slack/bin/slack`.
 
 **Common mistakes:** Don't use `which slack` to discover the binary — `which` resolves any shell alias and defeats the point of 1a. In Git Bash on Windows, use the POSIX probe form, not PowerShell.
@@ -109,7 +111,7 @@ SLACK_CMD api chat.postMessage channel=C0123456789 text="Hello from the CLI"
 
 **Important distinction**: `--team`, `--token`, `--json`, and `--data` are meta-flags (prefixed with `--`). API method parameters use positional `key=value` syntax without dashes.
 
-**Reference**: Full method list at https://docs.slack.dev/reference/methods.md.
+**Reference**: Full method list at <https://docs.slack.dev/reference/methods.md>.
 
 ---
 
@@ -147,7 +149,7 @@ SLACK_CMD login --no-prompt
 
 The CLI prints a `/slackauthticket <ticket>` slash command and exits. Capture the ticket — you will need it in step 4. Sample output:
 
-```
+```text
 📋 Run the following slash command from any Slack channel in the workspace
    you'd like to authenticate
 

--- a/skills/slack-cli/SKILL.md
+++ b/skills/slack-cli/SKILL.md
@@ -185,7 +185,7 @@ If you catch yourself thinking any of these, you are about to regress to the old
 
 | Rationalization | Reality |
 |---|---|
-| "`auth list` already shows teams, so login isn't needed." | Auth is per-team. The developer asked for a *new* team — drive the flow. |
+| "`auth list` already shows teams, so login isn't needed." | Auth is per-team. The developer asked for a _new_ team — drive the flow. |
 | "`slack login` needs browser confirmation, so I can't drive it." | False with `--no-prompt`. The challenge code appears in Slack's modal, not a browser. The agent runs both `slack login` invocations itself. |
 | "I should tell the developer to run `slack login` in a separate terminal." | Never. Step 5 is the agent's job from start to finish. |
 

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -28,9 +28,10 @@ Slack MCP accepts standard markdown. Use familiar markdown syntax when composing
 | Numbered list | `1. item` |
 
 Not supported:
-  - Tables       
-  - Headers `(#, ##, etc.)`            
-  - Images via markdown `(![alt](url))`
+
+- Tables
+- Headers `(#, ##, etc.)`
+- Images via markdown `(![alt](url))`
 
 ## Message Structure Guidelines
 

--- a/skills/slack-search/SKILL.md
+++ b/skills/slack-search/SKILL.md
@@ -36,6 +36,7 @@ Apply this skill whenever you need to find information in Slack — including wh
 ### Use Multiple Searches
 
 Don't rely on a single search. Break complex questions into smaller searches:
+
 - Search for the topic first
 - Then search for specific people's contributions
 - Then search in specific channels
@@ -43,17 +44,20 @@ Don't rely on a single search. Break complex questions into smaller searches:
 ## Search Modifiers Reference
 
 ### Location Filters
+
 - `in:channel-name` — Search within a specific channel
 - `in:<#C123456>` — Search in channel by ID
 - `-in:channel-name` — Exclude a channel
 - `in:<@U123456>` — Search in DMs with a user
 
 ### User Filters
+
 - `from:<@U123456>` — Messages from a specific user (by ID)
 - `from:username` — Messages from a user (by Slack username)
 - `to:me` — Messages sent directly to you
 
 ### Content Filters
+
 - `is:thread` — Only threaded messages
 - `has:pin` — Pinned messages
 - `has:link` — Messages containing links
@@ -61,12 +65,14 @@ Don't rely on a single search. Break complex questions into smaller searches:
 - `has::emoji:` — Messages with a specific reaction
 
 ### Date Filters
+
 - `before:YYYY-MM-DD` — Messages before a date
 - `after:YYYY-MM-DD` — Messages after a date
 - `on:YYYY-MM-DD` — Messages on a specific date
 - `during:month` — Messages during a specific month (e.g., `during:january`)
 
 ### Text Matching
+
 - `"exact phrase"` — Match an exact phrase
 - `-word` — Exclude messages containing a word
 - `wild*` — Wildcard matching (minimum 3 characters before `*`)
@@ -74,6 +80,7 @@ Don't rely on a single search. Break complex questions into smaller searches:
 ## File Search
 
 To search for files, use the `content_types="files"` parameter with type filters:
+
 - `type:images` — Image files
 - `type:documents` — Document files
 - `type:pdfs` — PDF files
@@ -85,6 +92,7 @@ Example: `content_types="files" type:pdfs budget after:2025-01-01`
 ## Following Up on Results
 
 After finding relevant messages:
+
 - Use `slack_read_thread` to get the full thread context for any threaded message.
 - Use `slack_read_channel` with `oldest`/`latest` timestamps to read surrounding messages for context.
 - Use `slack_read_user_profile` to identify who a user is when their ID appears in results.


### PR DESCRIPTION
## What

Introduce [rumdl](https://github.com/rvben/rumdl), a markdownlint-compatible Rust linter, into the toolchain.

## Changes

- **Tooling**
  - Add `rumdl` to the `[tools]` optional dependencies and a `[tool.rumdl]` config block in `pyproject.toml`.
  - Add `rumdl check` into `make lint` and `rumdl check --fix` into `make format`.
- **Markdown fixes** 
  - Apply the fixes flagged by `rumdl`

## Testing

- `make lint` — ruff + rumdl both pass (14 markdown files, 0 issues).
- `make test-unit` — 12 passed.
- `make typecheck` — clean.

## Notes

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)