### PR TITLE
fix(create-slack-app): drop --experiment=sandboxes flag

### DIFF
--- a/.changeset/drop-sandbox-experiment-flag.md
+++ b/.changeset/drop-sandbox-experiment-flag.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Drop the `--experiment=sandboxes` flag from `slack sandbox` invocations in the `create-slack-app` skill. The experiment has been removed from `slack-cli`, so the flag now surfaces an unknown-experiment warning that can confuse users and agents.

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -41,13 +41,13 @@ Wait for confirmation that authentication succeeded before proceeding.
 
 ## Step 3: Set Up a Developer Sandbox
 
-Run `SLACK_CMD sandbox list --experiment=sandboxes` to check if the developer already has a sandbox.
+Run `SLACK_CMD sandbox list` to check if the developer already has a sandbox.
 
 - **If a sandbox exists**: Show it and confirm they want to use it.
 - **If no sandbox exists**: Tell the developer to create one:
 
   ```text
-  ! SLACK_CMD sandbox create --experiment=sandboxes
+  ! SLACK_CMD sandbox create
   ```
 
   Alternatively, they can create one at <https://api.slack.com/developer-program/sandboxes> or join the Developer Program at <https://api.slack.com/developer-program/join>.


### PR DESCRIPTION
### Summary

Removes `--experiment=sandboxes` from the two `slack sandbox` invocations in `create-slack-app/SKILL.md`. The `sandboxes` experiment has been removed upstream in [`slackapi/slack-cli`](https://github.com/slackapi/slack-cli/blob/main/internal/experiment/experiment.go), so passing the flag is a no-op today, but the unknown experiment error could be confusing to humans and agents.

### Preview

Docs-only change; no UI to preview.

### Testing

- [x] `slack sandbox list` runs cleanly on a current CLI without the flag
- [x] `slack sandbox create` runs cleanly on a current CLI without the flag

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.