### PR TITLE
chore: add GitHub issue templates split by mcp and skills

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-question.yml
+++ b/.github/ISSUE_TEMPLATE/00-question.yml
@@ -1,0 +1,26 @@
+name: Question
+description: Ask a question about the Slack MCP or Skills plugin
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? Please provide as much context as possible so we can help.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Anything you've already tried, links to relevant docs, or the outcome
+        you're trying to reach.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/01-bug-mcp.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-mcp.yml
@@ -1,0 +1,90 @@
+name: MCP bug
+description: Report a bug in the Slack MCP server or its tools
+labels: ["bug", "area:mcp"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report an MCP bug. Please fill out as
+        much detail as you can — repro steps and version info help us the most.
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: |
+        Run `/plugin` inside Claude Code, or check the plugin listing in Cursor.
+      placeholder: e.g., 1.1.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: Client
+      description: Which AI tool were you using?
+      options:
+        - Claude Code
+        - Cursor
+        - Other (please describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: client-version
+    attributes:
+      label: Client version
+      description: Version of Claude Code, Cursor, or your MCP client
+      placeholder: e.g., Claude Code 2.0.14
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g., macOS 14.5, Ubuntu 22.04, Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Ask the AI to "..."
+        2. The MCP tool call to `...` runs
+        3. See error / unexpected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Include error messages, tool responses, or screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Optional. Logs, related issues, workspace permissions context, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/01-bug-mcp.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-mcp.yml
@@ -5,8 +5,19 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report an MCP bug. Please fill out as
-        much detail as you can — repro steps and version info help us the most.
+        Thank you for taking the time to report an MCP bug.
+
+        **Heads up:** this repository does not host the Slack MCP Server itself,
+        so bugs in the MCP Server can't be fixed here — but we can share your
+        feedback internally with the Slack MCP Server team.
+
+        For outages, rate limits, or other errors specific to your Slack team,
+        please report the issue to
+        [Slack Developer Platform Support](https://slack.com/help/requests/new)
+        so they can work with you privately to diagnose and resolve it.
+
+        Please fill out as much detail as you can — repro steps and version
+        info help us the most.
 
   - type: input
     id: plugin-version

--- a/.github/ISSUE_TEMPLATE/02-bug-skill.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-skill.yml
@@ -9,25 +9,26 @@ body:
         which skill or command is affected and how to reproduce it.
 
   - type: dropdown
-    id: skill
+    id: kind
     attributes:
-      label: Which skill or command?
-      description: Pick the closest match. Choose "Other" if it's not listed.
+      label: Which is affected?
       options:
-        - "skill: slack-messaging"
-        - "skill: slack-search"
-        - "skill: slack-api"
-        - "skill: slack-cli"
-        - "skill: create-slack-app"
-        - "skill: block-kit"
-        - "command: /slack:summarize-channel"
-        - "command: /slack:find-discussions"
-        - "command: /slack:draft-announcement"
-        - "command: /slack:standup"
-        - "command: /slack:channel-digest"
-        - Other (please describe below)
+        - Skill
+        - Slash command
+        - Not sure
     validations:
       required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name of the skill or command
+      description: |
+        For example: `slack-messaging`, `create-slack-app`, `/slack:standup`.
+        Leave blank if you're not sure.
+      placeholder: e.g., slack-messaging or /slack:standup
+    validations:
+      required: false
 
   - type: input
     id: plugin-version

--- a/.github/ISSUE_TEMPLATE/02-bug-skill.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-skill.yml
@@ -1,0 +1,112 @@
+name: Skill or command bug
+description: Report a bug in a skill or slash command
+labels: ["bug", "area:skills"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug in a skill or slash command. Please tell us
+        which skill or command is affected and how to reproduce it.
+
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Which skill or command?
+      description: Pick the closest match. Choose "Other" if it's not listed.
+      options:
+        - "skill: slack-messaging"
+        - "skill: slack-search"
+        - "skill: slack-api"
+        - "skill: slack-cli"
+        - "skill: create-slack-app"
+        - "skill: block-kit"
+        - "command: /slack:summarize-channel"
+        - "command: /slack:find-discussions"
+        - "command: /slack:draft-announcement"
+        - "command: /slack:standup"
+        - "command: /slack:channel-digest"
+        - Other (please describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: |
+        Run `/plugin` inside Claude Code, or check the plugin listing in Cursor.
+      placeholder: e.g., 1.1.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: Client
+      description: Which AI tool were you using?
+      options:
+        - Claude Code
+        - Cursor
+        - Other (please describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: client-version
+    attributes:
+      label: Client version
+      description: Version of Claude Code, Cursor, or your MCP client
+      placeholder: e.g., Claude Code 2.0.14
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g., macOS 14.5, Ubuntu 22.04, Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you ask the AI, and what did the skill/command do?
+      placeholder: |
+        1. Ran `/slack:summarize-channel #general`
+        2. ...
+        3. Saw ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Include error messages, output, or screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Optional. Logs, related issues, edge cases, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-feature-mcp.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-mcp.yml
@@ -1,0 +1,41 @@
+name: MCP feature request
+description: Request a new MCP tool or an improvement to the MCP server
+labels: ["enhancement", "area:mcp"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new MCP tool or an improvement to an existing one?
+        Tell us what problem you're trying to solve.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Focus on the outcome, not a specific implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the new tool or improvement look like?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Other tools, workflows, or workarounds you've tried.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Optional. Related issues, links, examples.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-feature-skill.yml
+++ b/.github/ISSUE_TEMPLATE/04-feature-skill.yml
@@ -1,0 +1,55 @@
+name: Skill or command feature request
+description: Request a new skill, a new slash command, or an improvement to an existing one
+labels: ["enhancement", "area:skills"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new skill, a new slash command, or an improvement to
+        an existing one? Tell us what problem you're trying to solve.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of change is this?
+      options:
+        - New skill
+        - New slash command
+        - Improvement to an existing skill
+        - Improvement to an existing slash command
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Focus on the outcome, not a specific implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        What would the new skill, command, or improvement look like? Include
+        example prompts if you have them.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Other tools, workflows, or workarounds you've tried.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Optional. Related issues, links, examples.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05-docs.yml
+++ b/.github/ISSUE_TEMPLATE/05-docs.yml
@@ -1,0 +1,33 @@
+name: Documentation
+description: Report a problem or suggest an improvement to the documentation
+labels: ["docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs. Point us at the specific page or
+        section and tell us what needs to change.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where is the docs issue?
+      description: URL or path to the docs page, README section, or SKILL.md file.
+      placeholder: e.g., https://docs.slack.dev/... or skills/block-kit/SKILL.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: Optional. Draft text or a description of the fix.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack Developer Platform Support
+    url: https://slack.com/help/requests/new
+    about: |
+      This issue tracker is for bugs, feature requests, and questions about the
+      Slack MCP and Skills plugin. For general Slack platform or workspace
+      questions, please contact support via the link above.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Slack Developer Platform Support
     url: https://slack.com/help/requests/new
     about: |
-      This issue tracker is for bugs, feature requests, and questions about the
-      Slack MCP and Skills plugin. For general Slack platform or workspace
-      questions, please contact support via the link above.
+      For outages, rate limits, or other errors specific to your Slack team,
+      please report the issue to Slack Developer Platform Support. They can
+      work with you privately to diagnose and resolve the problem.


### PR DESCRIPTION
### Summary

Adds YAML issue forms under `.github/ISSUE_TEMPLATE/` so incoming issues self-route to either the MCP surface or the Skills surface at creation time. Each template applies static `labels:` - no GitHub Actions required and no maintainer touch on first triage.

Templates:

| File | Auto-labels |
|---|---|
| `00-question.yml` | `question` |
| `01-bug-mcp.yml` | `bug`, `area:mcp` |
| `02-bug-skill.yml` | `bug`, `area:skills` |
| `03-feature-mcp.yml` | `enhancement`, `area:mcp` |
| `04-feature-skill.yml` | `enhancement`, `area:skills` |
| `05-docs.yml` | `docs` |
| `config.yml` | disables blank issues, contact link for general platform questions |

The bug-skill template also has a "which skill or command?" dropdown so maintainers can drill into a specific surface without reading the body first.

The `area:mcp` (blue) and `area:skills` (green) labels were created on the repo before this PR so the templates can reference them.

### Preview

The template picker will show all six options in numeric order (00–05).

### Testing

- [x] All 7 YAML files parse (`python3 -c 'import yaml; yaml.safe_load(open(f))'`)
- [x] All 6 referenced labels exist on the repo (`bug`, `enhancement`, `question`, `docs`, `area:mcp`, `area:skills`)
- [ ] After merge: open a scratch issue from each template, confirm the correct labels drop, then close

### Notes

- The `area:mcp` / `area:skills` split matches how maintainers already triage the repo (MCP server vs. skills + slash commands).
- "Both surfaces" case: user picks one template, maintainer adds the second label. Same amount of touch as any single-template + Action approach, without the Action.
- The `question` template does not auto-apply an `area:*` label since questions often span both surfaces or neither.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.