### PR TITLE
fix(claude): update homepage to be the slack-mcp-plugin repo instead of nonexistent

### DIFF
--- a/.changeset/fix-plugin-homepage.md
+++ b/.changeset/fix-plugin-homepage.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Fix the `homepage` field in `.claude-plugin/plugin.json` to point to this repository instead of `slackapi/slack-mcp-cursor-plugin`, which does not exist and returned a 404.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,6 @@
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://github.com/slackapi/slack-mcp-cursor-plugin",
+  "homepage": "https://github.com/slackapi/slack-mcp-plugin",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

The `homepage` field in `.claude-plugin/plugin.json` currently points to `https://github.com/slackapi/slack-mcp-cursor-plugin`, which returns a 404 — that repository does not exist.

This PR updates it to point to this repo's own GitHub URL, `https://github.com/slackapi/slack-mcp-plugin`.

## Why

- Broken link surfaced in Claude Code and any tooling that reads the plugin manifest's `homepage`.
- Trivial one-line fix; opening as draft so a maintainer can confirm the intended homepage (this repo vs. a future dedicated docs page on `docs.slack.dev`).