### PR TITLE
docs: point repo references at slackapi/slack-skills-plugin

### DIFF
--- a/.changeset/rename-repo-to-slack-skills-plugin.md
+++ b/.changeset/rename-repo-to-slack-skills-plugin.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Update the `homepage` field in `.claude-plugin/plugin.json` and repo links in docs to point to `slackapi/slack-skills-plugin`, the repository's new name.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,6 @@
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://github.com/slackapi/slack-mcp-plugin",
+  "homepage": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT"
 }

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -7,15 +7,15 @@ well.
 There are many ways you can contribute! :heart:
 
 ### Bug Reports and Fixes :bug:
--  If you find a bug, please search for it in the [Issues](https://github.com/slackapi/slack-mcp-cursor-plugin/issues), and if it isn't already tracked,
-   [create a new issue](https://github.com/slackapi/slack-mcp-cursor-plugin/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
+-  If you find a bug, please search for it in the [Issues](https://github.com/slackapi/slack-skills-plugin/issues), and if it isn't already tracked,
+   [create a new issue](https://github.com/slackapi/slack-skills-plugin/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
    be reviewed.
 -  Issues that have already been identified as a bug (note: able to reproduce) will be labelled `bug`.
 -  If you'd like to submit a fix for a bug, [send a Pull Request](#creating_a_pull_request) and mention the Issue number.
   -  Include tests that isolate the bug and verifies that it was fixed.
 
 ### New Features :bulb:
--  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/slackapi/slack-mcp-cursor-plugin/issues/new).
+-  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/slackapi/slack-skills-plugin/issues/new).
 -  Issues that have been identified as a feature request will be labelled `enhancement`.
 -  If you'd like to implement the new feature, please wait for feedback from the project
    maintainers before spending too much time writing the code. In some cases, `enhancement`s may
@@ -26,7 +26,7 @@ There are many ways you can contribute! :heart:
    alternative implementation of something that may have advantages over the way its currently
    done, or you have any other change, we would be happy to hear about it!
   -  If its a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
-  -  If not, [open an Issue](https://github.com/slackapi/slack-mcp-cursor-plugin/issues/new) to discuss the idea first.
+  -  If not, [open an Issue](https://github.com/slackapi/slack-skills-plugin/issues/new) to discuss the idea first.
 
 If you're new to our project and looking for some way to make your first contribution, look for
 Issues labelled `good first contribution`.

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -1,7 +1,7 @@
 # Maintainers Guide
 
 This document describes tools, tasks, and workflows needed to maintain the
-`slackapi/slack-mcp-plugin` repository. This is a skills plugin
+`slackapi/slack-skills-plugin` repository. This is a skills plugin
 marketplace, so the primary maintenance work is keeping skill content accurate
 and plugin versions correct rather than managing build artifacts or package
 registries.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,6 @@
 
 ### Requirements
 
-- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-mcp-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
+- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
 - [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 - [ ] I've run `make test` and the tests pass.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Claude Code][claude-code] and [Cursor][cursor] plugin that brings Slack into your AI tools with a [Slack MCP Server][slack-mcp-docs] and set of Slack skills for both users and developers.
 
-[![CI Build](https://github.com/slackapi/slack-mcp-plugin/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/slack-mcp-plugin/actions/workflows/ci-build.yml)
+[![CI Build](https://github.com/slackapi/slack-skills-plugin/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/slack-skills-plugin/actions/workflows/ci-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Installation

--- a/tests/support/tools.py
+++ b/tests/support/tools.py
@@ -11,7 +11,7 @@ from tests.skill import discover_skills
 
 __all__ = ["get_all_skill_tools", "get_slack_mcp_tools"]
 
-_CLIENT_INFO = types.Implementation(name="slack-mcp-skills-tests", version="0.0.0")
+_CLIENT_INFO = types.Implementation(name="slack-skills-tests", version="0.0.0")
 
 
 def get_all_skill_tools() -> list[ToolCall]:


### PR DESCRIPTION
### Summary

We have renamed our GitHub repo from `slackapi/slack-mcp-plugin` to `slackapi/slack-skills-plugin` to capture the MCP & Skills AI Coding Agent Plugin feature set. This pull request updates the repo's docs files to match the new name:

- Update the `homepage` field in `.claude-plugin/plugin.json` to point at `slackapi/slack-skills-plugin` (the repo's new name).
- Update the CI badge in `README.md`, the Contributing Guidelines link in the PR template, and the repo reference in the maintainers guide.
- Fix 4 pre-existing broken `slack-mcp-cursor-plugin` Issues links in `.github/contributing.md` while we're touching related files.

The historical changeset entry at `.changeset/fix-plugin-homepage.md` is intentionally left as-is since it describes a past fix.

Env vars (`SLACK_MCP_TOKEN`, `SLACK_MCP_URL`) are intentionally unchanged - they refer to the Slack-hosted MCP server, not this plugin.

### Preview

N/A - text-only changes to docs and metadata; no user-facing UI to preview.

### Testing

- `grep -rn "slack-mcp-plugin\|slack-mcp-cursor-plugin" --include='*.md' --include='*.json' --include='*.toml' --include='*.yml' --include='*.py' --include='Makefile' .` returns only the historical `.changeset/fix-plugin-homepage.md` entry.
- `.claude-plugin/plugin.json` remains valid JSON (`python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"`).
- After merge, confirm the README badge on GitHub renders and links to the new repo's Actions page.

### Notes

- User installs and updates will continue working via GitHub's automatic redirect from the old repo URL.
- Contributors may want to run `git remote set-url origin https://github.com/slackapi/slack-skills-plugin.git` to update it.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.