### PR TITLE
feat: add unofficial Codex plugin surface

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Developer Tools"
+      "category": "Productivity"
     }
   ]
 }

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "slack-dev",
+  "interface": {
+    "displayName": "Slack (dev)"
+  },
+  "plugins": [
+    {
+      "name": "slack",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.changeset/add-codex-plugin-surface.md
+++ b/.changeset/add-codex-plugin-surface.md
@@ -1,0 +1,7 @@
+---
+"slack": minor
+---
+
+Add a Codex plugin surface. A new `.codex-plugin/plugin.json` manifest exposes the Slack skills to [Codex][codex], and a repo-scoped `.agents/plugins/marketplace.json` lets you install the plugin into Codex from a local checkout. The hosted MCP server is not yet wired into the Codex surface; skills only for now.
+
+[codex]: https://developers.openai.com/codex

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,19 +1,19 @@
 {
   "name": "slack",
   "version": "1.1.0",
-  "description": "Slack integration for searching messages, sending communications, managing canvases, and more",
+  "description": "Bring Slack into your AI tools with a Slack MCP server and Slack skills",
   "author": {
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://github.com/slackapi/slack-skills-plugin",
+  "homepage": "https://docs.slack.dev",
   "repository": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT",
   "skills": "./skills/",
   "interface": {
     "displayName": "Slack",
-    "shortDescription": "Slack integration for searching messages, sending communications, managing canvases, and more",
-    "longDescription": "Slack integration for searching messages, sending communications, managing canvases, and more",
+    "shortDescription": "Slack MCP server and skills for your AI tools",
+    "longDescription": "Connect your AI tools to Slack through the Slack MCP server to search messages, files, and channels, send and schedule messages, read threads, and manage canvases. Includes skills for building Slack apps with the Slack CLI and Bolt, calling Web API methods, and composing Block Kit layouts.",
     "developerName": "Slack",
     "category": "Productivity",
     "capabilities": [
@@ -21,6 +21,6 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/slackapi/slack-skills-plugin"
+    "websiteURL": "https://docs.slack.dev/ai/mcp-server/"
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slack",
   "version": "1.1.0",
-  "description": "Bring Slack into your AI tools with a Slack MCP server and Slack skills",
+  "description": "Slack skills for building apps with the Slack CLI, Bolt, Web API, and Block Kit",
   "author": {
     "name": "Slack",
     "url": "https://slack.com"
@@ -10,10 +10,12 @@
   "repository": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT",
   "skills": "./skills/",
+  "mcpServers": {},
   "interface": {
     "displayName": "Slack",
-    "shortDescription": "Slack MCP server and skills for your AI tools",
-    "longDescription": "Connect your AI tools to Slack through the Slack MCP server to search messages, files, and channels, send and schedule messages, read threads, and manage canvases. Includes skills for building Slack apps with the Slack CLI and Bolt, calling Web API methods, and composing Block Kit layouts.",
+    "shortDescription": "Slack skills for your AI tools",
+    "longDescription": "Skills for building Slack apps with the Slack CLI and Bolt, calling Web API methods, and composing Block Kit layouts, plus skills for searching and messaging in Slack when a Slack MCP server is connected.",
+    "defaultPrompt": "Help me build a Slack app with the Slack CLI and Bolt.",
     "developerName": "Slack",
     "category": "Productivity",
     "capabilities": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "slack",
+  "version": "1.1.0",
+  "description": "Slack integration for searching messages, sending communications, managing canvases, and more",
+  "author": {
+    "name": "Slack",
+    "url": "https://slack.com"
+  },
+  "homepage": "https://github.com/slackapi/slack-skills-plugin",
+  "repository": "https://github.com/slackapi/slack-skills-plugin",
+  "license": "MIT",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Slack",
+    "shortDescription": "Slack integration for searching messages, sending communications, managing canvases, and more",
+    "longDescription": "Slack integration for searching messages, sending communications, managing canvases, and more",
+    "developerName": "Slack",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/slackapi/slack-skills-plugin"
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://docs.slack.dev",
+  "homepage": "https://docs.slack.dev/ai/slack-skills-plugin",
   "repository": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT",
   "skills": "./skills/",
@@ -23,6 +23,6 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://docs.slack.dev/ai/mcp-server/"
+    "websiteURL": "https://docs.slack.dev/ai/slack-skills-plugin"
   }
 }

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -15,6 +15,8 @@ Maintaining this repo requires:
   Code rather than traditional CLI tooling.
 - **[Cursor][cursor]**: an alternative agentic coding environment. Useful for
   verifying that skills and commands work outside Claude Code before release.
+- **[Codex][codex-cli]**: another agentic coding environment. Useful for
+  verifying that the skills work outside Claude Code before release.
 - **Git**: standard version control.
 - **[GitHub CLI (`gh`)][gh-cli]**: for creating PRs as drafts and managing
   issues.
@@ -134,6 +136,30 @@ This copies the plugin into `~/.cursor/plugins/slack@local` and registers it.
 To remove it, run `make cursor-uninstall`. (`make clean` also runs the Cursor
 uninstall, in addition to removing the virtualenv and other generated files.)
 
+### Testing in Codex
+
+Codex loads plugins only from a marketplace. The repo ships a development marketplace at
+`.agents/plugins/marketplace.json` that points at this checkout, so you can add
+it as a local marketplace and install the plugin from it.
+
+Register the local marketplace and install the `slack` plugin:
+
+```sh
+codex plugin marketplace add ./
+codex plugin add slack@slack-dev
+```
+
+`codex plugin list` shows the plugin; `codex /plugins` opens the same flow interactively. Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
+
+To remove it
+
+```sh
+codex plugin remove slack@slack-dev
+codex plugin marketplace remove slack-dev
+```
+
+Codex support currently ships only the skills; the hosted MCP server is not yet wired into the Codex surface.
+
 ---
 
 ## Versioning
@@ -215,6 +241,7 @@ Patch and minor updates are auto-approved and auto-merged via the
 
 [claude-code]: https://claude.ai/code
 [cursor]: https://cursor.com
+[codex-cli]: https://developers.openai.com/codex/cli
 [gh-cli]: https://cli.github.com
 [conv-commits]: https://www.conventionalcommits.org
 [semver]: https://semver.org

--- a/scripts/sync_versions.py
+++ b/scripts/sync_versions.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_JSON_PATH = REPO_ROOT / "package.json"
 CLAUDE_PLUGIN_PATH = REPO_ROOT / ".claude-plugin" / "plugin.json"
 CURSOR_PLUGIN_PATH = REPO_ROOT / ".cursor-plugin" / "plugin.json"
+CODEX_PLUGIN_PATH = REPO_ROOT / ".codex-plugin" / "plugin.json"
 
 
 def read_version(package_path: Path) -> str:
@@ -32,6 +33,7 @@ def main() -> None:
     version = read_version(PACKAGE_JSON_PATH)
     write_version(CLAUDE_PLUGIN_PATH, version)
     write_version(CURSOR_PLUGIN_PATH, version)
+    write_version(CODEX_PLUGIN_PATH, version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds **unofficial Codex support** to this plugin by exposing the Slack skills through a Codex plugin surface. This mirrors the existing Claude Code and Cursor surfaces.

- New `.codex-plugin/plugin.json` manifest that exposes the skills to [Codex](https://developers.openai.com/codex), version-matched to the other plugin manifests.
- `scripts/sync_versions.py` now keeps the Codex manifest version in lockstep with `package.json`, the Claude, and Cursor manifests.

The hosted MCP server is **not yet wired into the Codex surface**, this ships the skills only for now.

## Preview

<img width="1312" height="138" alt="Screenshot 2026-07-23 at 1 45 24 PM" src="https://github.com/user-attachments/assets/202bddb6-918d-40d9-9c8a-3824e4a70a4c" />

## Test plan

- [x] `codex plugin marketplace add ./` then `codex plugin add slack@slack-dev` installs the plugin from a local checkout
- [x] Skills are invocable in a Codex session (e.g. `$block-kit`)
- [x] `make lint` / `make typecheck` / `make test-unit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)