### PR TITLE
docs: align Claude Code and Cursor plugin manifest metadata

### DIFF
--- a/.changeset/align-plugin-manifest-metadata.md
+++ b/.changeset/align-plugin-manifest-metadata.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Align the install-surface metadata across the Claude Code and Cursor plugin manifests. Refresh the `.claude-plugin/plugin.json` description, add a `repository` field to both manifests, point `homepage` at the `docs.slack.dev` developer hub, and add the JSON Schema reference to the Claude Code manifest for editor validation.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,13 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "slack",
-  "description": "Slack integration for searching messages, sending communications, managing canvases, and more",
+  "description": "Bring Slack into your AI tools with a Slack MCP server and Slack skills",
   "version": "1.1.0",
   "author": {
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://github.com/slackapi/slack-skills-plugin",
+  "homepage": "https://docs.slack.dev",
+  "repository": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://docs.slack.dev",
+  "homepage": "https://docs.slack.dev/ai/slack-skills-plugin",
   "repository": "https://github.com/slackapi/slack-skills-plugin",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -4,7 +4,10 @@
   "version": "1.1.0",
   "mcpServers": "../.cursor-mcp.json",
   "author": {
-    "name": "Slack"
+    "name": "Slack",
+    "url": "https://slack.com"
   },
+  "homepage": "https://docs.slack.dev",
+  "repository": "https://github.com/slackapi/slack-skills-plugin",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Slack",
     "url": "https://slack.com"
   },
-  "homepage": "https://docs.slack.dev",
+  "homepage": "https://docs.slack.dev/ai/slack-skills-plugin",
   "repository": "https://github.com/slackapi/slack-skills-plugin",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## What

Brings the `.claude-plugin` and `.cursor-plugin` manifests in line with the install-surface cleanup done for the Codex surface (PR #96), so all three plugin manifests describe the plugin consistently.

## Changes

Both `homepage` and `repository` are documented, supported fields in each surface's manifest schema.

## Testing

- `make lint` — passes (ruff + rumdl)
- `make test-unit` — 18 passed
- JSON validated for both manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)