### PR TITLE
docs: clarify slack_read_thread uses message_ts not thread_ts

### DIFF
--- a/.changeset/document-read-thread-message-ts.md
+++ b/.changeset/document-read-thread-message-ts.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Document that `slack_read_thread` takes the thread timestamp as `message_ts`, not `thread_ts`. Search permalinks surface this value as `?thread_ts=<ts>`, so the slack-search skill and the find-discussions, standup, and summarize-channel commands now call out the correct parameter name to prevent a failed first call and retry.

--- a/commands/find-discussions.md
+++ b/commands/find-discussions.md
@@ -6,7 +6,7 @@ Given the topic provided in $ARGUMENTS:
 
 1. Use the `slack_search_public` tool to search for messages matching the topic. Use the topic as a natural language question first for semantic results.
 2. If semantic results are sparse, follow up with a keyword search using key terms from the topic.
-3. For the most relevant results, use `slack_read_thread` to fetch full thread conversations so you capture the complete discussion context.
+3. For the most relevant results, use `slack_read_thread` to fetch full thread conversations so you capture the complete discussion context. Pass the thread's `channel_id` and the timestamp from the result's permalink (`?thread_ts=<ts>`) as `message_ts` — the parameter is named `message_ts`, not `thread_ts`.
 4. Present the results organized by relevance:
    - For each discussion found, show: the channel name, who started it, a brief summary of the conversation, and the date.
    - Group related discussions together if they span multiple channels.

--- a/commands/standup.md
+++ b/commands/standup.md
@@ -11,7 +11,7 @@ description: Generate a standup update based on your recent Slack activity
    - **What I'm working on next** — Any mentions of upcoming work, plans, or follow-ups
    - **Blockers** — Any questions asked that went unanswered, issues raised, or explicit mentions of being stuck
 
-4. For messages in threads, use `slack_read_thread` to get the full context so you can accurately describe what the user contributed.
+4. For messages in threads, use `slack_read_thread` to get the full context so you can accurately describe what the user contributed. Pass the message's timestamp from the search results as `message_ts` — the parameter is named `message_ts`, not `thread_ts`.
 
 5. Format the standup as:
 

--- a/commands/summarize-channel.md
+++ b/commands/summarize-channel.md
@@ -6,7 +6,7 @@ Given the channel name provided in $ARGUMENTS (strip any leading `#`):
 
 1. Use the `slack_search_channels` tool to find the channel ID for the provided channel name. Strip any leading `#` from the argument before searching.
 2. Use the `slack_read_channel` tool to read recent messages from the channel (default limit of 100 messages).
-3. For any messages that have threads with replies, use `slack_read_thread` to read the thread contents so the summary captures threaded discussions.
+3. For any messages that have threads with replies, use `slack_read_thread` to read the thread contents so the summary captures threaded discussions. Pass the parent message's timestamp as `message_ts` — the parameter is named `message_ts`, not `thread_ts`.
 4. Produce a concise summary organized by topic or theme. The summary should include:
    - An overview of the main topics discussed
    - Key decisions or action items mentioned

--- a/skills/slack-search/SKILL.md
+++ b/skills/slack-search/SKILL.md
@@ -93,7 +93,7 @@ Example: `content_types="files" type:pdfs budget after:2025-01-01`
 
 After finding relevant messages:
 
-- Use `slack_read_thread` to get the full thread context for any threaded message.
+- Use `slack_read_thread` to get the full thread context for any threaded message. It takes the thread's `channel_id` and the parent message's timestamp — but the timestamp parameter is named `message_ts`, **not** `thread_ts`. A result's permalink shows this value as `?thread_ts=<ts>`; pass that `<ts>` under `message_ts`.
 - Use `slack_read_channel` with `oldest`/`latest` timestamps to read surrounding messages for context.
 - Use `slack_read_user_profile` to identify who a user is when their ID appears in results.
 
@@ -103,3 +103,4 @@ After finding relevant messages:
 - **Parentheses don't work.** Don't try to group search terms with `()`.
 - **Search is not real-time.** Very recent messages (last few seconds) may not appear in search results. Use `slack_read_channel` for the most recent messages.
 - **Private channel access.** Use `slack_search_public_and_private` when you need to include private channels, but note this requires user consent.
+- **`slack_read_thread` expects `message_ts`, not `thread_ts`.** Search permalinks contain `?thread_ts=<ts>`, but the tool's timestamp parameter is named `message_ts`. Pass the timestamp value under `message_ts` (with the thread's `channel_id`) — a call using `thread_ts` is rejected.


### PR DESCRIPTION
### Summary

This pull request documents that `slack_read_thread` takes the thread timestamp under `message_ts`, not `thread_ts`, to eliminate a recurring failed-call-and-retry cycle.

- Closes #57.
- The search tools return permalinks containing `?thread_ts=<ts>`, so LLM agents pattern-match `thread_ts` and call `slack_read_thread` with the wrong parameter name; the server rejects it and the agent retries with `message_ts`, costing ~750ms plus tokens each time.
- The server-side fix (accepting `thread_ts` as an alias) lives in the closed-source MCP server and is tracked internally; this PR addresses the experience from the open-source side.
- Updates the `slack-search` skill in two spots: the *Following Up on Results* bullet and a new *Common Pitfalls* entry.
- Adds a short `message_ts`-not-`thread_ts` reminder to the `find-discussions`, `standup`, and `summarize-channel` commands, which call `slack_read_thread` directly.
- Includes a `slack` patch changeset.

### Preview

N/A — documentation-only change (skill and command prompt text).

### Testing

- Read the updated `skills/slack-search/SKILL.md` and the three command prompts and confirm each names `message_ts` as the correct parameter and ties it to the `?thread_ts=` permalink value.
- Optional end-to-end sanity check: run `slack_search_public_and_private`, take a result permalink's `thread_ts` value, and confirm `slack_read_thread { channel_id, message_ts }` succeeds on the first call.

### Notes

Intentionally does **not** add an eval scenario: `tests/eval/test_tool_selection.py` only validates which tool the model selects, not parameter values, so it cannot exercise this fix.

Verified locally with `make lint` and `make test-unit` (both pass). The eval layer of `make test` was not run locally as it needs `GEMINI_API_KEY`/`SLACK_MCP_TOKEN`; CI runs it.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `make test` and the tests pass.