### PR TITLE
docs: replace Cursor MCP deeplink with Marketplace plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ The Slack MCP server is configured automatically. You'll be prompted to authenti
 
 ### Cursor
 
-The plugin is published on the [official Cursor Marketplace](https://cursor.com/marketplace/slack). Install it directly into Cursor:
+The plugin is published on the [official Cursor Marketplace](https://cursor.com/marketplace/slack). Install it from inside Cursor:
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=slack&config=eyJ1cmwiOiJodHRwczovL21jcC5zbGFjay5jb20vbWNwIiwiYXV0aCI6eyJDTElFTlRfSUQiOiIzNjYwNzUzMTkyNjI2Ljg5MDM0NjkyMjg5ODIifX0%3D)
+```text
+/add-plugin slack
+```
 
-After install, Cursor surfaces a connect button - use it to authenticate to your Slack workspace.
+This installs the skills, commands, and MCP server together. You'll be prompted to authenticate to your Slack workspace via OAuth on first use.
 
 ## Features
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -25,9 +25,13 @@ The plugin is published on the [official Claude marketplace](https://claude.com/
 
 ### Installing the plugin for Cursor
 
-The plugin is published on the [official Cursor Marketplace](https://cursor.com/marketplace/slack). You can install the plugin by clicking the nifty button below:
+The plugin is published on the [official Cursor Marketplace](https://cursor.com/marketplace/slack). You can install the plugin directly from a Cursor Agent chat with a slash command:
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=slack&config=eyJ1cmwiOiJodHRwczovL21jcC5zbGFjay5jb20vbWNwIiwiYXV0aCI6eyJDTElFTlRfSUQiOiIzNjYwNzUzMTkyNjI2Ljg5MDM0NjkyMjg5ODIifX0=")
+```sh
+/add-plugin slack
+```
+
+Alternatively, search for "slack" in the Cursor plugin marketplace. This installs the skills, and MCP server together, and prompts OAuth to your Slack workspace on first use.
 
 ---
 


### PR DESCRIPTION
## Summary

The Cursor install instructions pointed users at the Marketplace but handed them an **MCP-only install deeplink** (`cursor.com/en-US/install-mcp?...`). That deeplink wires up only the Slack MCP server and silently skips the 6 skills and 5 commands the plugin bundles.

## Testing

- `make lint` passes.

Docs-only change, so no changeset.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)