### PR TITLE
docs: sharpen slack-messaging and slack-search skill guidance

### DIFF
--- a/.changeset/sharpen-messaging-search-skills.md
+++ b/.changeset/sharpen-messaging-search-skills.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Sharpen the slack-messaging and slack-search skill guidance: clearer trigger descriptions, accurate standard-markdown formatting rules (tables, headers, code blocks), more search modifiers and parameters, and scope notes linking to related skills.

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-messaging
-description: Compose and format effective Slack messages sent via the Slack MCP tools. Use whenever writing, drafting, or improving a Slack message, announcement, reply, or canvas. Covers standard markdown formatting, message structure, thread etiquette, reactions, and scheduling.
+description: Compose and format effective Slack messages sent via the Slack MCP tools. Use whenever writing, drafting, scheduling, or improving a Slack message, announcement, or reply. Covers standard markdown formatting, message structure, thread etiquette, reactions, and scheduling, and points to the right dialect for canvases and Block Kit.
 ---
 
 # Slack Messaging Best Practices
@@ -9,11 +9,11 @@ This skill provides guidance for composing well-formatted, effective Slack messa
 
 ## When to Use
 
-Apply this skill whenever composing, drafting, or helping the user write a Slack message, including when using `slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`, or `slack_create_canvas`.
+Apply this skill whenever composing, drafting, or helping the user write a Slack message, including when using `slack_send_message`, `slack_send_message_draft`, or `slack_schedule_message`. The formatting rules below cover these message tools. `slack_create_canvas` uses a different, richer markdown dialect — see the Canvas note below.
 
 ## Formatting
 
-The Slack MCP messaging tools accept **standard markdown** and convert it to Slack formatting on send. Write normal markdown. Do **not** use Slack's legacy `mrkdwn` syntax (`*bold*`, `~strike~`); those single-character forms mean something different in standard markdown. Each text element is limited to ~5000 characters.
+The message tools (`slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`) accept **standard markdown** and convert it to Slack formatting on send. Write normal markdown. Do **not** use Slack's legacy `mrkdwn` syntax (`*bold*`, `~strike~`); those single-character forms mean something different in standard markdown. Each text element is limited to ~5000 characters.
 
 | Format        | Syntax                 |
 | ------------- | ---------------------- |
@@ -50,7 +50,7 @@ Block elements also work. Write them as literal markdown:
   ## Section title
   ```
 
-The one thing that does **not** embed: inline images (`![alt](url)`) render as a plain link, not an inline image. For rich embedded layouts (buttons, images, structured cards) you need Block Kit. See the Notes below.
+The one thing that does **not** embed in a message: inline images (`![alt](url)`) typically render as a plain link rather than an inline image. For rich embedded layouts (buttons, images, structured cards) you need Block Kit; for a document-style surface where images do embed, use a canvas. See the Notes below.
 
 ## Message Structure Guidelines
 
@@ -73,6 +73,12 @@ The one thing that does **not** embed: inline images (`![alt](url)`) render as a
 - For simple acknowledgments, add an emoji reaction with `slack_add_reaction` instead of a reply message (use `slack_get_reactions` to read existing reactions).
 - When writing announcements, use a clear structure: context, key info, call to action.
 
+## Scheduling
+
+- Use `slack_schedule_message` to post later. `post_at` is a Unix timestamp that must be at least 2 minutes in the future and at most 120 days out; the message body uses the same standard markdown as above.
+- Scheduled messages can't be edited via the API once set — the user manages them from **Drafts & sent** in Slack.
+
 ## Notes
 
-- **Scope:** this skill owns composing and formatting the _text_ of messages sent through the Slack MCP tools. For interactive layouts (buttons, menus, modals, Home tabs, or any Block Kit JSON), use the `slack:block-kit` skill, which composes and validates the block payload. For calling the Slack Web API directly (`chat.postMessage` and friends) rather than the MCP tools, use the `slack:slack-api` skill.
+- **Canvas formatting is different.** `slack_create_canvas` uses Canvas-flavored Markdown, a richer dialect than the message tools: headers, tables, checklists, and inline images (`![alt](url)`) all embed, and it also supports user/channel reference cards, callouts, and columns. Do **not** assume the message rules above apply — follow the `slack_create_canvas` tool's own formatting guidance when composing a canvas.
+- **Scope:** this skill owns composing and formatting the _text_ of messages sent through the Slack MCP message tools. For interactive layouts (buttons, menus, modals, Home tabs, or any Block Kit JSON), use the `slack:block-kit` skill, which composes and validates the block payload. For calling the Slack Web API directly (`chat.postMessage` and friends) rather than the MCP tools, use the `slack:slack-api` skill.

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-messaging
-description: Guidance for composing well-formatted, effective Slack messages using standard markdown
+description: Compose and format effective Slack messages sent via the Slack MCP tools. Use whenever writing, drafting, or improving a Slack message, announcement, reply, or canvas. Covers standard markdown formatting, message structure, thread etiquette, reactions, and scheduling.
 ---
 
 # Slack Messaging Best Practices
@@ -9,47 +9,70 @@ This skill provides guidance for composing well-formatted, effective Slack messa
 
 ## When to Use
 
-Apply this skill whenever composing, drafting, or helping the user write a Slack message — including when using `slack_send_message`, `slack_send_message_draft`, or `slack_create_canvas`.
+Apply this skill whenever composing, drafting, or helping the user write a Slack message, including when using `slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`, or `slack_create_canvas`.
 
 ## Formatting
 
-Slack MCP accepts standard markdown. Use familiar markdown syntax when composing messages:
+The Slack MCP messaging tools accept **standard markdown** and convert it to Slack formatting on send. Write normal markdown. Do **not** use Slack's legacy `mrkdwn` syntax (`*bold*`, `~strike~`); those single-character forms mean something different in standard markdown. Each text element is limited to ~5000 characters.
 
-| Format | Syntax |
-|--------|--------|
-| Bold | `**text**` |
-| Italic | `_text_` or `*text*` |
-| Strikethrough | `~text~` |
-| Code (inline) | `` `code` `` |
-| Code block | `` ```code``` `` |
-| Quote | `> text` |
-| Link | `[display text](url)` |
-| Bulleted list | `- item` |
-| Numbered list | `1. item` |
+| Format        | Syntax                 |
+| ------------- | ---------------------- |
+| Bold          | `**text**`             |
+| Italic        | `_text_` (or `*text*`) |
+| Strikethrough | `~~text~~`             |
+| Code (inline) | `` `code` ``           |
+| Quote         | `> text`               |
+| Link          | `[display text](url)`  |
+| Bulleted list | `- item`               |
+| Numbered list | `1. item`              |
 
-Not supported:
+Block elements also work. Write them as literal markdown:
 
-- Tables
-- Headers `(#, ##, etc.)`
-- Images via markdown `(![alt](url))`
+- **Code block** with an optional language for syntax highlighting:
+
+  ````text
+  ```python
+  print("hello")
+  ```
+  ````
+
+- **Table** with `|` delimiters (escape a literal pipe inside a cell as `\|`):
+
+  ```text
+  | Feature | Status |
+  |---------|--------|
+  | Tables  | works  |
+  ```
+
+- **Headers** with `#` / `##` / `###`:
+
+  ```text
+  ## Section title
+  ```
+
+The one thing that does **not** embed: inline images (`![alt](url)`) render as a plain link, not an inline image. For rich embedded layouts (buttons, images, structured cards) you need Block Kit. See the Notes below.
 
 ## Message Structure Guidelines
 
 - **Lead with the point.** Put the most important information in the first line. Many people read Slack on mobile or in notifications where only the first line shows.
-- **Keep it short.** Aim for 1-3 short paragraphs. If the message is long, consider using a Canvas instead.
+- **Keep it short.** Aim for 1-3 short paragraphs (the ~5000-character limit is a ceiling, not a target). If the message is long or structured, consider a Canvas instead.
 - **Use line breaks generously.** Walls of text are hard to read. Separate distinct thoughts with blank lines.
 - **Use bullet points for lists.** Anything with 3+ items should be a list, not a run-on sentence.
-- **Bold key information.** Use `*bold*` for names, dates, deadlines, and action items so they stand out when scanning.
+- **Bold key information.** Use `**bold**` for names, dates, deadlines, and action items so they stand out when scanning.
 
 ## Thread vs. Channel Etiquette
 
 - **Reply in threads** when responding to a specific message to keep the main channel clean.
 - **Use `reply_broadcast`** (also post to channel) only when the reply contains information everyone needs to see.
 - **Post in the channel** (not a thread) when starting a new topic, making an announcement, or asking a question to the whole group.
-- **Don't start a new thread** to continue an existing conversation — find and reply to the original message.
+- **Don't start a new thread** to continue an existing conversation; find and reply to the original message.
 
 ## Tone and Audience
 
-- Match the tone to the channel — `#general` is usually more formal than `#random`.
-- Use emoji reactions instead of reply messages for simple acknowledgments (though note: the MCP tools can't add reactions, so suggest the user do this manually if appropriate).
+- Match the tone to the channel: `#general` is usually more formal than `#random`.
+- For simple acknowledgments, add an emoji reaction with `slack_add_reaction` instead of a reply message (use `slack_get_reactions` to read existing reactions).
 - When writing announcements, use a clear structure: context, key info, call to action.
+
+## Notes
+
+- **Scope:** this skill owns composing and formatting the _text_ of messages sent through the Slack MCP tools. For interactive layouts (buttons, menus, modals, Home tabs, or any Block Kit JSON), use the `slack:block-kit` skill, which composes and validates the block payload. For calling the Slack Web API directly (`chat.postMessage` and friends) rather than the MCP tools, use the `slack:slack-api` skill.

--- a/skills/slack-search/SKILL.md
+++ b/skills/slack-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-search
-description: Guidance for effectively searching Slack to find messages, files, channels, and people
+description: Find messages, files, channels, and people across Slack with the search MCP tools. Use whenever locating conversations, gathering context before answering, or looking someone up. Covers search modifiers, file-type filters, natural-language vs. keyword search, and reading results in context.
 ---
 
 # Slack Search
@@ -9,16 +9,16 @@ This skill provides guidance for effectively searching Slack to find messages, f
 
 ## When to Use
 
-Apply this skill whenever you need to find information in Slack — including when a user asks you to locate messages, conversations, files, or people, or when you need to gather context before answering a question about what's happening in Slack.
+Apply this skill whenever you need to find information in Slack, including when a user asks you to locate messages, conversations, files, or people, or when you need to gather context before answering a question about what's happening in Slack.
 
 ## Search Tools Overview
 
-| Tool | Use When |
-|------|----------|
-| `slack_search_public` | Searching public channels only. Does not require user consent. |
+| Tool                              | Use When                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------ |
+| `slack_search_public`             | Searching public channels only. Does not require user consent.                       |
 | `slack_search_public_and_private` | Searching all channels including private, DMs, and group DMs. Requires user consent. |
-| `slack_search_channels` | Finding channels by name or description. |
-| `slack_search_users` | Finding people by name, email, or role. |
+| `slack_search_channels`           | Finding channels by name or description.                                             |
+| `slack_search_users`              | Finding people by name, email, or role.                                              |
 
 ## Search Strategy
 
@@ -30,8 +30,8 @@ Apply this skill whenever you need to find information in Slack — including wh
 
 ### Choose the Right Search Mode
 
-- **Natural language questions** (e.g., "What is the deadline for project X?") — Best for fuzzy, conceptual searches where you don't know exact keywords.
-- **Keyword search** (e.g., `project X deadline`) — Best for finding specific, exact content.
+- **Natural language questions** (e.g., "What is the deadline for project X?"): Best for fuzzy, conceptual searches where you don't know exact keywords.
+- **Keyword search** (e.g., `project X deadline`): Best for finding specific, exact content.
 
 ### Use Multiple Searches
 
@@ -45,49 +45,61 @@ Don't rely on a single search. Break complex questions into smaller searches:
 
 ### Location Filters
 
-- `in:channel-name` — Search within a specific channel
-- `in:<#C123456>` — Search in channel by ID
-- `-in:channel-name` — Exclude a channel
-- `in:<@U123456>` — Search in DMs with a user
+- `in:channel-name`: Search within a specific channel
+- `in:<#C123456>`: Search in channel by ID
+- `-in:channel-name`: Exclude a channel
+- `in:<@U123456>` or `in:@username`: Search in DMs with a user
 
 ### User Filters
 
-- `from:<@U123456>` — Messages from a specific user (by ID)
-- `from:username` — Messages from a user (by Slack username)
-- `to:me` — Messages sent directly to you
+- `from:<@U123456>`: Messages from a specific user (by ID)
+- `from:username`: Messages from a user (by Slack username)
+- `to:<@U123456>`: Messages sent to a specific user
+- `to:me`: Messages sent directly to you
+- `creator:@username`: Canvases created by a specific person
 
 ### Content Filters
 
-- `is:thread` — Only threaded messages
-- `has:pin` — Pinned messages
-- `has:link` — Messages containing links
-- `has:file` — Messages with file attachments
-- `has::emoji:` — Messages with a specific reaction
+- `is:thread`: Only threaded messages
+- `is:saved`: Only your saved messages
+- `has:pin`: Pinned messages
+- `has:link`: Messages containing links
+- `has:file`: Messages with file attachments
+- `has::emoji:`: Messages with a specific reaction
+- `hasmy::emoji:`: Messages you reacted to with a specific reaction
 
 ### Date Filters
 
-- `before:YYYY-MM-DD` — Messages before a date
-- `after:YYYY-MM-DD` — Messages after a date
-- `on:YYYY-MM-DD` — Messages on a specific date
-- `during:month` — Messages during a specific month (e.g., `during:january`)
+- `before:YYYY-MM-DD`: Messages before a date
+- `after:YYYY-MM-DD`: Messages after a date
+- `on:YYYY-MM-DD`: Messages on a specific date
+- `during:month`: Messages during a specific month (e.g., `during:january`)
 
 ### Text Matching
 
-- `"exact phrase"` — Match an exact phrase
-- `-word` — Exclude messages containing a word
-- `wild*` — Wildcard matching (minimum 3 characters before `*`)
+- `"exact phrase"`: Match an exact phrase
+- `-word`: Exclude messages containing a word
+- `wild*`: Wildcard matching (minimum 3 characters before `*`)
 
 ## File Search
 
-To search for files, use the `content_types="files"` parameter with type filters:
+To search for files, set the `content_types="files"` parameter and use a `type:` filter in the query:
 
-- `type:images` — Image files
-- `type:documents` — Document files
-- `type:pdfs` — PDF files
-- `type:spreadsheets` — Spreadsheet files
-- `type:canvases` — Slack Canvases
+- `type:images`, `type:documents`, `type:pdfs`, `type:spreadsheets`, `type:presentations`
+- `type:canvases`, `type:lists`, `type:emails`, `type:audio`, `type:videos`
 
 Example: `content_types="files" type:pdfs budget after:2025-01-01`
+
+All the standard modifiers above (`in:`, `from:`, dates, etc.) work with file searches too.
+
+## Useful Parameters
+
+Beyond the query string, the search tools accept parameters that materially improve results:
+
+- `sort`: `score` (relevance, default) or `timestamp` (newest first); pair with `sort_dir` (`asc`/`desc`).
+- `content_types`: `messages` (default) or `files`.
+- `only_my_channels`: restrict to channels you're a member of.
+- `limit`: results per page (capped at 20); paginate with the returned `cursor`.
 
 ## Following Up on Results
 
@@ -96,10 +108,16 @@ After finding relevant messages:
 - Use `slack_read_thread` to get the full thread context for any threaded message.
 - Use `slack_read_channel` with `oldest`/`latest` timestamps to read surrounding messages for context.
 - Use `slack_read_user_profile` to identify who a user is when their ID appears in results.
+- Use `slack_read_file` to read the contents of a file surfaced by a file search.
+- Use `slack_list_channel_members` to see who is in a channel you found.
 
 ## Common Pitfalls
 
-- **Boolean operators don't work.** `AND`, `OR`, `NOT` are not supported. Use spaces (implicit AND) and `-` for exclusion.
+- **Boolean operators don't work.** `AND`, `OR`, `NOT` are not supported. Use spaces (implicit AND) and `-` for exclusion. (Repeating the same modifier, e.g. two `from:`, ORs those values together.)
 - **Parentheses don't work.** Don't try to group search terms with `()`.
 - **Search is not real-time.** Very recent messages (last few seconds) may not appear in search results. Use `slack_read_channel` for the most recent messages.
 - **Private channel access.** Use `slack_search_public_and_private` when you need to include private channels, but note this requires user consent.
+
+## Notes
+
+- **Scope:** this skill owns searching _workspace content_: messages, files, channels, and people inside Slack. To search and read the official Slack _platform documentation_ at docs.slack.dev (conceptual and how-to questions about Slack features), use the `slack:slack-docs` skill instead.


### PR DESCRIPTION
### Summary

This pull request sharpens the guidance in the `slack-messaging` and `slack-search` skills so they trigger more reliably and describe the MCP tools accurately.

- Rewrote both skill descriptions with concrete trigger phrases instead of vague summaries.
- Corrected the messaging formatting rules: the message tools accept **standard markdown** and convert on send, so tables, headers, and fenced code blocks *do* work.
- Scoped canvas correctly: `slack_create_canvas` uses a different, richer Canvas-flavored Markdown dialect (images embed there), so it now has its own note instead of being lumped in with the message-formatting rules.

### Testing

- `make lint`
- `make test-unit`

Try these prompts against the installed plugin to exercise the updated guidance:

- "Send a message to #team with a markdown table comparing our Q1 and Q2 numbers." → should format a real table (previously the skill claimed tables were unsupported).
- "Draft an announcement with a header and a code snippet." → should use `##` headers and fenced code blocks.
- "Schedule that reminder for 9am tomorrow." → should use `slack_schedule_message` and respect the `post_at` window.
- "Make a canvas with an embedded diagram image." → should follow the canvas note, not the message image rule.
- "React to that message with :eyes: instead of replying." → should reach for `slack_add_reaction`.
- "Find every PDF shared in #finance after January." → should use `content_types="files"` with `type:pdfs` and a date filter.
- "What did Jordan say about the launch date?" → should use a natural-language search with a `from:` filter.
- "Show me messages I saved about onboarding." → should use `is:saved`.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass. <!-- Ran `make lint` + `make test-unit` (all pass); did not run `make test-eval`, which needs a Gemini API key. CI will run the full suite. -->
