### PR TITLE
Disclose host-added attribution before Slack sends

### DIFF
--- a/.changeset/disclose-host-attribution.md
+++ b/.changeset/disclose-host-attribution.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Warn before a connected AI host adds sender attribution to an outgoing Slack message, and offer a manual-send path when attribution-free delivery matters.

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -11,6 +11,15 @@ This skill provides guidance for composing well-formatted, effective Slack messa
 
 Apply this skill whenever composing, drafting, or helping the user write a Slack message, including when using `slack_send_message`, `slack_send_message_draft`, or `slack_schedule_message`. The formatting rules below cover these message tools. `slack_create_canvas` uses a different, richer markdown dialect — see the Canvas note below.
 
+## Connector Attribution
+
+Some AI hosts append a sender attribution such as “Sent using ChatGPT” after a message sent through a connected Slack tool. That footer is added by the host, is not part of the message text the user reviewed, and may not be removable by editing the message afterward.
+
+- Apply this preflight only immediately before a real post or scheduled post. Do not show it for compose-only or rewrite-only work, or for `slack_send_message_draft`; those actions do not send.
+- When the current host is known to add an attribution, stop and ask the user to choose between sending with the attribution or receiving final text to paste directly in Slack. Do not call the send or schedule tool until they choose. This matters especially when they say “as me,” use a mass mention, or are writing to customers.
+- If attribution-free delivery matters, prepare the final text and have the user paste or send it directly in Slack instead of calling the send tool.
+- Do not add the attribution to the drafted text yourself, and do not promise that a later edit can remove a host-added footer.
+
 ## Formatting
 
 The message tools (`slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`) accept **standard markdown** and convert it to Slack formatting on send. Write normal markdown. Do **not** use Slack's legacy `mrkdwn` syntax (`*bold*`, `~strike~`); those single-character forms mean something different in standard markdown. Each text element is limited to ~5000 characters.

--- a/tests/unit/test_slack_messaging_contract.py
+++ b/tests/unit/test_slack_messaging_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_connector_attribution_is_disclosed_before_sending() -> None:
+    skill = (PLUGIN_ROOT / "skills" / "slack-messaging" / "SKILL.md").read_text()
+
+    assert "sender attribution" in skill
+    assert "stop and ask the user to choose" in skill
+    assert "Do not call the send or schedule tool until they choose" in skill
+    assert "as me" in skill
+    assert "paste or send it directly in Slack" in skill
+    assert "do not promise that a later edit can remove" in skill
+
+
+def test_connector_attribution_preflight_does_not_block_drafts() -> None:
+    skill = (PLUGIN_ROOT / "skills" / "slack-messaging" / "SKILL.md").read_text()
+
+    attribution = skill.split("## Connector Attribution", 1)[1].split("## Formatting", 1)[0]
+    assert "only immediately before a real post or scheduled post" in attribution
+    assert "compose-only or rewrite-only work" in attribution
+    assert "`slack_send_message_draft`" in attribution
+    assert "those actions do not send" in attribution


### PR DESCRIPTION
### Summary

Add a connector-attribution preflight to `slack-messaging` so an agent:

- tells the user when its current host adds sender attribution
- pauses for an explicit choice before a real or scheduled post
- offers final text for manual paste when attribution-free delivery matters
- does not interrupt compose-only, rewrite-only, or draft-only work

This avoids surprising someone who asked the agent to post “as me,” especially for mass mentions or customer-facing messages.

### Preview

Documentation and behavioral contract tests only.

### Testing

- `make lint`
- `make test-unit` (20 passed)
- `make typecheck`

The LLM eval suite was not run locally because it requires `GEMINI_API_KEY` and `SLACK_MCP_TOKEN`.

### Notes

The attribution is added by the host rather than the reviewed message body, so the skill does not promise that an edit can remove it.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `make test` and the tests pass.
