### PR TITLE
Updates Skills Plugin descriptions to capture dev capabilities

### DIFF
--- a/.changeset/clarify-plugin-descriptions.md
+++ b/.changeset/clarify-plugin-descriptions.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Clarify Claude and Cursor plugin manifest descriptions so both user and developer audiences are discoverable. The Codex manifest describes skills only and does not claim workspace interaction, since the MCP server is not wired into the Codex surface.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "slack",
-  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills for developing Slack apps.",
+  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills to develop Slack apps.",
   "version": "1.2.0",
   "author": {
     "name": "Slack",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "slack",
-  "description": "Bring Slack into your AI tools with a Slack MCP server and Slack skills",
+  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills for developing Slack apps.",
   "version": "1.2.0",
   "author": {
     "name": "Slack",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slack",
   "version": "1.2.0",
-  "description": "Slack skills for building apps with the Slack CLI, Bolt, Web API, and Block Kit",
+  "description": "Slack skills for developing apps with the Slack CLI, Bolt frameworks, Web API, and Block Kit",
   "author": {
     "name": "Slack",
     "url": "https://slack.com"
@@ -13,9 +13,9 @@
   "mcpServers": {},
   "interface": {
     "displayName": "Slack",
-    "shortDescription": "Slack skills for your AI tools",
-    "longDescription": "Skills for building Slack apps with the Slack CLI and Bolt, calling Web API methods, and composing Block Kit layouts, plus skills for searching and messaging in Slack when a Slack MCP server is connected.",
-    "defaultPrompt": "Help me build a Slack app with the Slack CLI and Bolt.",
+    "shortDescription": "Slack skills for developers",
+    "longDescription": "Skills for developing Slack apps with the Slack CLI and Bolt frameworks, calling Web API methods, and composing Block Kit layouts.",
+    "defaultPrompt": "Help me develop a Slack app with the Slack CLI and Bolt.",
     "developerName": "Slack",
     "category": "Productivity",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slack",
-  "description": "Slack MCP server. Search channels, send messages, and perform other Slack actions through MCP-compatible clients.",
+  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills for developing Slack apps.",
   "version": "1.2.0",
   "mcpServers": "../.cursor-mcp.json",
   "author": {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slack",
-  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills for developing Slack apps.",
+  "description": "Slack AI tools for users and developers: interact with your workspace via the Slack MCP server and use skills to develop Slack apps.",
   "version": "1.2.0",
   "mcpServers": "../.cursor-mcp.json",
   "author": {


### PR DESCRIPTION
### Summary

Right now AI tools aren't realizing this is for developers too. This makes it more apparent. Purposefuly made the cursor and claude ones be the exact same wording 

Also the codex description said it supported the MCP server, but it doesn't right now.

### Preview

n/a

### Testing

n/a 

### Requirements

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `make test` and the tests pass.
