### PR TITLE
fix(block-kit): simplify and harden CLI validation

### DIFF
--- a/.changeset/block-kit-cli-preflight.md
+++ b/.changeset/block-kit-cli-preflight.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Make Block Kit validation resolve and use the Slack CLI before falling back to curl.

--- a/.changeset/block-kit-cli-preflight.md
+++ b/.changeset/block-kit-cli-preflight.md
@@ -2,4 +2,4 @@
 "slack": patch
 ---
 
-Make Block Kit validation resolve and use the Slack CLI before falling back to curl.
+Simplify the Block Kit skill and make validation resolve and use the Slack CLI before falling back to curl.

--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -34,6 +34,22 @@ Never use a block type, element, or field you have not seen on a live page.
 
 ---
 
+## Resolve Tooling
+
+Before choosing the Fast Path, Modification Mode, or full workflow, use the
+`slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to resolve the public
+Slack CLI command once. Keep the result as either `SLACK_CMD` or an explicit
+reason the CLI is unavailable. This is a capability check only; do not
+authenticate, validate, or write Slack CLI configuration during this preflight.
+For Block Kit validation, stop after the standard-path and `PATH` probes in
+that detection step. If neither resolves the CLI, record it as unavailable and
+use curl; do not propose installation or ask about an alias unless the developer
+independently asked to configure the Slack CLI.
+
+All later validation and preview steps must reuse this result.
+
+---
+
 ## Fast Path (for clear, specific requests)
 
 If the developer's request is specific enough to determine both the target surface and the desired layout, collapse Steps 1-4 into a single pass:
@@ -178,15 +194,40 @@ The authoritative reference for this method (its parameters, auth requirements, 
 
 ### 5a. Build the validation request
 
-Prefer the Slack CLI when it's available, since it reuses the slack-cli skill's CLI detection and needs no token wrangling. If the CLI isn't installed, fall back to curl. Both call the same public method and return the same response, so Step 5b applies either way.
+Use the tooling result resolved before layout work. If `SLACK_CMD` resolved, you
+MUST attempt validation with the Slack CLI. Use curl only when the CLI was not
+found or its API command cannot run after the handling below. A Slack API
+validation response with `"ok": false` means the CLI ran successfully; fix the
+payload and retry with the CLI rather than switching transports.
 
 **Path A: Slack CLI (preferred).**
 
-Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
+Use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**,
+for the argument-passing contract. The canonical `blocks.validate` invocation
+below is already known: attempt it directly without running `api --help`,
+`--version`, or generic help first.
 
-If the CLI is available, use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**, to invoke it. That step covers the `SLACK_CMD api <method> key=value …` syntax. Run `SLACK_CMD api --help` first to confirm the syntax **and the flag that skips authentication**. `blocks.validate` needs no token, so call it without authentication. Don't hard-code that flag from memory; read it from the help output so this stays correct if it's ever renamed. Pass the payload as a positional `key=value` argument: `blocks=<JSON array>` for messages, or `view=<JSON view object>` for modals and home tabs.
+```bash
+$SLACK_CMD api blocks.validate --no-auth 'blocks=[...]'
+$SLACK_CMD api blocks.validate --no-auth 'view={...}'
+```
 
-**Path B: curl (fallback, when the CLI isn't installed).**
+If the command cannot start because the host blocks writes to the Slack CLI's
+config or log path, ask for the host's normal narrowly scoped permission and
+retry the identical command. Never activate a permission bypass. If permission
+is denied or unavailable, preserve the error, report that validation did not
+run, and stop; do not use another transport to evade that boundary. If the
+canonical attempt reports an incompatible CLI, record its version and
+diagnostic help output before deciding that the API command cannot execute; do
+not silently invent a different CLI invocation. For another non-permission
+execution failure, use curl only as an explicitly disclosed fallback.
+
+**Path B: curl (fallback).**
+
+Use curl only when the resolved preflight state says the CLI is absent, or the
+CLI call cannot execute after the policy-compliant handling above. Do not use
+curl to hide payload errors, Slack API errors, or a network/service failure that
+would affect either transport. Retain the exact fallback reason for Step 6.
 
 POST to the endpoint with the **Bash tool**. The API uses form-urlencoded encoding, so pass the JSON directly as the parameter value.
 
@@ -241,7 +282,17 @@ When validation fails:
 
 ## Step 6: Deliver the Final Output
 
-Present the validated payload, then help the developer put it to use.
+Present the validated payload, then help the developer put it to use. State
+whether validation ran through the Slack CLI or curl. If it ran through curl,
+state the recorded reason the CLI path was unavailable or unable to execute.
+
+Use one of these stable disclosures:
+
+- `Validation transport: Slack CLI (<resolved command>).`
+- `Validation transport: curl (Slack CLI unavailable: <reason>).`
+
+If validation did not succeed, state `Validation status: not validated
+(<reason>).` Never imply success from a transport attempt alone.
 
 ### Send it
 
@@ -253,13 +304,14 @@ Help the developer view their layout with the **Block Kit Builder**. Prefer the 
 
 **Path A: Slack CLI (preferred).**
 
-Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
-
-If the CLI is available, run `SLACK_CMD blocks preview --help` to see how to pass the blocks and open the preview. The command loads the blocks into the Block Kit Builder in the developer's browser.
+Reuse the `SLACK_CMD` recorded in **Resolve Tooling**. If it is available, run
+`SLACK_CMD blocks preview --help` to see how to pass the blocks and open the
+preview. The command loads the blocks into the Block Kit Builder in the
+developer's browser.
 
 Because you run the CLI non-interactively, this command also needs a `--team` flag. Resolve the team ID with the `slack:slack-cli` skill, **Step 2: Command Discovery via Help**, whose "Resolving `--app` and `--team` values" guidance covers running `SLACK_CMD auth list`; Any authenticated workspace works for a preview, if several are available, pick one and mention which you used rather than blocking on the choice.
 
-**Path B: Block Kit Builder link (fallback, when the CLI isn't installed).**
+**Path B: Block Kit Builder link (fallback, when Resolve Tooling recorded the CLI as unavailable).**
 
 Offer the Block Kit Builder link so the developer can paste the JSON in and tweak visually: `https://app.slack.com/block-kit-builder`. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
 

--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: block-kit
-description: 'Help developers build and validate Block Kit layouts for Slack messages, modals, and Home tabs. Provides authoritative block references and validates with the blocks.validate API. Use this skill whenever the developer wants to compose Slack message layouts, build modals/forms/dialogs, design Home tab interfaces, create interactive messages with buttons or menus, modify existing Block Kit JSON, or asks about any Slack UI component (sections, actions, inputs, headers, alerts, tables, carousels). Also trigger when they mention "blocks", "Block Kit Builder", want to preview or see the rendered version of blocks, or paste JSON containing block structures like `"type": "section"`.'
-argument-hint: "[message | modal | home-tab]"
+description: 'Help users build and validate Block Kit layouts for Slack messages, modals, and Home tabs. Provides authoritative block references and validates with the blocks.validate API. Use this skill whenever the user wants to compose Slack message layouts, build modals/forms/dialogs, design Home tab interfaces, create interactive messages with buttons or menus, modify existing Block Kit JSON, or asks about any Slack UI component (sections, actions, inputs, headers, alerts, tables, carousels). Also trigger when they mention "blocks", "Block Kit Builder", want to preview or see the rendered version of blocks, or paste JSON containing block structures like `"type": "section"`.'
 ---
 
 # Block Kit
 
-Help the developer build a rich Block Kit layout. If `$0` is provided, it specifies the target surface (`message`, `modal`, or `home-tab`).
+Help the user build a rich Block Kit layout.
 
 This skill walks through surface selection, layout planning, JSON generation, and validation. Block types, elements, and fields come from the live docs (see **Source of Truth** below) — discover them and read each component's schema there, never from memory.
 
@@ -41,10 +40,14 @@ Before choosing the Fast Path, Modification Mode, or full workflow, use the
 Slack CLI command once. Keep the result as either `SLACK_CMD` or an explicit
 reason the CLI is unavailable. This is a capability check only; do not
 authenticate, validate, or write Slack CLI configuration during this preflight.
-For Block Kit validation, stop after the standard-path and `PATH` probes in
-that detection step. If neither resolves the CLI, record it as unavailable and
-use curl; do not propose installation or ask about an alias unless the developer
-independently asked to configure the Slack CLI.
+For Block Kit validation, follow that detection step's standard-path probe, the
+`PATH` probe, and the alias inquiry/verification branch. Do not propose
+installation unless the user independently asked to configure the Slack CLI. If
+the standard path and `PATH` probes fail, ask whether the public Slack CLI is
+installed under a different name or alias. If the user supplies an alias,
+verify it with `<alias> _fingerprint 2>/dev/null` before setting `SLACK_CMD`.
+If no alias is supplied or verified, record the CLI as unavailable and use
+curl.
 
 All later validation and preview steps must reuse this result.
 
@@ -52,32 +55,32 @@ All later validation and preview steps must reuse this result.
 
 ## Fast Path (for clear, specific requests)
 
-If the developer's request is specific enough to determine both the target surface and the desired layout, collapse Steps 1-4 into a single pass:
+If the user's request is specific enough to determine both the target surface and the desired layout, collapse Steps 1-4 into a single pass:
 
-1. Determine the surface from `$0` or context
+1. Determine the surface from context
 2. Fetch only the doc pages for the blocks and elements mentioned
 3. Generate the JSON directly
 4. Proceed to Step 5 (validation)
 
 **Fast-path indicators** (skip the full workflow):
 
-- Developer provides existing JSON to modify → use Modification Mode instead
-- Developer names specific block types: "add an actions block with two buttons"
-- Developer describes a well-known pattern: "approval message", "feedback form", "settings modal"
-- Developer provides a complete description in one message with enough detail to build
+- User provides existing JSON to modify → use Modification Mode instead
+- User names specific block types: "add an actions block with two buttons"
+- User describes a well-known pattern: "approval message", "feedback form", "settings modal"
+- User provides a complete description in one message with enough detail to build
 
 **Full-workflow indicators** (use Steps 1-7):
 
 - Vague requests: "make something cool", "build a dashboard"
 - Exploratory: "what can Block Kit do?", "show me my options"
 - Complex layouts: 10+ blocks, nested modals, conditional logic
-- Developer asks for help deciding what to build
+- User asks for help deciding what to build
 
 ---
 
 ## Modification Mode
 
-If the developer provides existing Block Kit JSON (pasted inline, in a file, or referenced from code), enter Modification Mode instead of the full creation workflow:
+If the user provides existing Block Kit JSON (pasted inline, in a file, or referenced from code), enter Modification Mode instead of the full creation workflow:
 
 1. **Parse the existing structure:**
    - List each block by index, type, and a short description of its content
@@ -96,15 +99,14 @@ If the developer provides existing Block Kit JSON (pasted inline, in a file, or 
 
 4. **Validate the modified JSON**: proceed to Step 5 (validation)
 
-**Detection:** If the developer's message contains a JSON array starting with `[{"type":` or a view object with `"blocks":`, enter Modification Mode automatically. If they say "edit", "update", "modify", or "change" in reference to existing blocks, ask them to provide the current JSON.
+**Detection:** If the user's message contains a JSON array starting with `[{"type":` or a view object with `"blocks":`, enter Modification Mode automatically. If they say "edit", "update", "modify", or "change" in reference to existing blocks, ask them to provide the current JSON.
 
 ---
 
 ## Step 1: Determine the Target Surface
 
-If `$0` is provided and matches one of `message`, `modal`, or `home-tab`, use it directly.
-
-Otherwise, ask the developer using AskUserQuestion:
+Determine the target surface from context. If it is genuinely ambiguous, ask
+the user with the host's available user-input mechanism:
 
 - **Message**: Conversational content posted to a channel or DM. Max 50 blocks.
 - **Modal**: A dialog or form opened by a user action. Max 100 blocks.
@@ -120,15 +122,9 @@ Once the surface is determined, use the correct payload structure for it:
 
 ## Step 2: Understand What to Build
 
-Ask the developer to describe what they want their layout to look like or accomplish.
-
-If they need inspiration, suggest examples — several map directly onto a ready-made template in `references/common-patterns.md` (named in parentheses), which you can start from in Step 3:
-
-- "A feedback form with a text input and a category selector" (Simple Form Modal)
-- "A notification message with an alert banner, description, and Approve/Reject buttons" (Notification Alert / Approval Message)
-- "A dashboard home tab with a welcome header, key metrics in fields, and quick-action buttons" (Dashboard Home Tab)
-- "A settings modal with dropdowns, checkboxes, and a time picker" (Settings Modal with Multiple Input Types)
-- "A table of sprint tasks with status and points" (Data Table)
+Ask the user to describe what they want their layout to look like or accomplish.
+If they need inspiration, consult `references/common-patterns.md` and suggest a
+relevant ready-made template that can be used as the starting point in Step 3.
 
 Get enough detail to plan the layout before generating any JSON.
 
@@ -136,7 +132,7 @@ Get enough detail to plan the layout before generating any JSON.
 
 ## Step 3: Plan the Block Layout
 
-Based on the developer's description:
+Based on the user's description:
 
 1. **Fetch only what you need** from the live docs:
    - WebFetch the master index (`https://docs.slack.dev/reference/block-kit.md`) to confirm the block and element types you plan to use exist and to grab links to their pages.
@@ -152,14 +148,7 @@ Based on the developer's description:
    5. actions: "Approve" button (primary) and "Reject" button (danger)
    ```
 
-3. Present the outline to the developer and ask for approval or changes before generating JSON.
-
-**Surface constraints to check:**
-
-- Block count limit: 50 for messages, 100 for modals/home tabs
-- Modal-specific: if using `input` blocks, the modal payload must include a `submit` field
-- Table: only one `table` block per message
-- Surface compatibility (whether a block is valid on the chosen surface) and element compatibility (whether an element is allowed inside a given block) are not always spelled out on a component's doc page. Build the layout from the docs, and let `blocks.validate` in Step 5 confirm it. It is the authoritative check.
+3. Present the outline to the user and ask for approval or changes before generating JSON.
 
 ---
 
@@ -170,11 +159,11 @@ Once the layout is approved, build each block from its live doc page, fetching e
 **Guidelines:**
 
 - Use descriptive `action_id` values (e.g., `"approve_report_btn"` not `"action_1"`) — they identify the element in your interaction handlers
-- Include `block_id` values where the developer will need them for interaction handling
+- Include `block_id` values where the user will need them for interaction handling
 - For modals, include `title`, `submit`, `close`, and `callback_id`; for home tabs, the `type: "home"` wrapper
 - Use `mrkdwn` text for rich formatting, `plain_text` where required (headers, labels, modal title)
 
-**mrkdwn vs. the `markdown` block:** `section` and `context` blocks format text with Slack's `mrkdwn` (`*bold*`, `_italic_`, `~strike~`, `` `code` ``) — use these for short, interactive layouts. The separate `markdown` block (Messages only) renders _standard_ markdown (`**bold**`, headings, tables, numbered lists) and is meant for AI/LLM-generated or long-form content that already exists in standard markdown. Reach for it when the developer has such content or needs those features in the message body; there is a cumulative 12,000-character limit across all `markdown` blocks in one message.
+**mrkdwn vs. the `markdown` block:** `section` and `context` blocks format text with Slack's `mrkdwn` (`*bold*`, `_italic_`, `~strike~`, `` `code` ``) — use these for short, interactive layouts. The separate `markdown` block (Messages only) renders _standard_ markdown (`**bold**`, headings, tables, numbered lists) and is meant for AI/LLM-generated or long-form content that already exists in standard markdown. Reach for it when the user has such content or needs those features in the message body; there is a cumulative 12,000-character limit across all `markdown` blocks in one message.
 
 **Accessibility** is easy to skip and hard to retrofit, so build it in now:
 
@@ -182,7 +171,7 @@ Once the layout is approved, build each block from its live doc page, fetching e
 - Summarize the layout in the message's `text` fallback (notifications and screen readers show it instead of the blocks)
 - Use `header` blocks for logical section headings — they convey document structure to assistive tech
 
-Present the complete payload to the developer in the Step 1 surface structure.
+Present the complete payload to the user in the Step 1 surface structure.
 
 ---
 
@@ -203,9 +192,10 @@ payload and retry with the CLI rather than switching transports.
 **Path A: Slack CLI (preferred).**
 
 Use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**,
-for the argument-passing contract. The canonical `blocks.validate` invocation
-below is already known: attempt it directly without running `api --help`,
-`--version`, or generic help first.
+for its positional `key=value` argument-passing contract. The public
+`blocks.validate --no-auth` form below is a documented exception to that
+skill's generic help-first rule: attempt it directly without running `api
+--help`, `--version`, or generic help first.
 
 ```bash
 $SLACK_CMD api blocks.validate --no-auth 'blocks=[...]'
@@ -217,17 +207,22 @@ config or log path, ask for the host's normal narrowly scoped permission and
 retry the identical command. Never activate a permission bypass. If permission
 is denied or unavailable, preserve the error, report that validation did not
 run, and stop; do not use another transport to evade that boundary. If the
-canonical attempt reports an incompatible CLI, record its version and
-diagnostic help output before deciding that the API command cannot execute; do
-not silently invent a different CLI invocation. For another non-permission
-execution failure, use curl only as an explicitly disclosed fallback.
+canonical attempt reports an incompatible CLI or another non-permission
+execution failure such that the `blocks.validate` API command itself cannot
+execute, record its version and diagnostic help output, then use curl with that
+precise execution-failure reason disclosed in Step 6. Do not silently invent a
+different CLI invocation. A parsed Slack semantic `"ok": false` response, a
+payload error, or a network/service failure still counts as the CLI path
+executing; fix or report that result on the CLI path rather than switching
+transports.
 
 **Path B: curl (fallback).**
 
-Use curl only when the resolved preflight state says the CLI is absent, or the
-CLI call cannot execute after the policy-compliant handling above. Do not use
-curl to hide payload errors, Slack API errors, or a network/service failure that
-would affect either transport. Retain the exact fallback reason for Step 6.
+Use curl only when the resolved preflight state says the CLI is absent, or when
+the canonical CLI invocation cannot execute for a non-permission reason after
+the handling above. Do not use curl to hide payload errors, Slack API semantic
+errors, or a network/service failure that affects a CLI invocation that already
+executed. Retain the exact absence or execution-failure reason for Step 6.
 
 POST to the endpoint with the **Bash tool**. The API uses form-urlencoded encoding, so pass the JSON directly as the parameter value.
 
@@ -253,7 +248,7 @@ curl -s -X POST 'https://slack.com/api/blocks.validate' \
 { "ok": true }
 ```
 
-Tell the developer their blocks are valid.
+Tell the user their blocks are valid.
 
 **Failure:**
 
@@ -282,14 +277,16 @@ When validation fails:
 
 ## Step 6: Deliver the Final Output
 
-Present the validated payload, then help the developer put it to use. State
+Present the validated payload, then help the user put it to use. State
 whether validation ran through the Slack CLI or curl. If it ran through curl,
-state the recorded reason the CLI path was unavailable or unable to execute.
+state the recorded reason the CLI was unavailable or why the canonical CLI
+invocation could not execute.
 
 Use one of these stable disclosures:
 
 - `Validation transport: Slack CLI (<resolved command>).`
 - `Validation transport: curl (Slack CLI unavailable: <reason>).`
+- `Validation transport: curl (Slack CLI execution failure: <reason>; version/help recorded).`
 
 If validation did not succeed, state `Validation status: not validated
 (<reason>).` Never imply success from a transport attempt alone.
@@ -300,26 +297,26 @@ Building the payload is this skill's job; sending it (`chat.postMessage`, `views
 
 ### Preview it
 
-Help the developer view their layout with the **Block Kit Builder**. Prefer the Slack CLI if it is installed. The CLI automatically loads the blocks, saving the developer from copying and pasting. If the CLI is not available, provide the standard Builder link instead.
+Help the user view their layout with the **Block Kit Builder**. Prefer the Slack CLI if it is installed. The CLI automatically loads the blocks, saving the user from copying and pasting. If the CLI is not available, provide the standard Builder link instead.
 
 **Path A: Slack CLI (preferred).**
 
 Reuse the `SLACK_CMD` recorded in **Resolve Tooling**. If it is available, run
 `SLACK_CMD blocks preview --help` to see how to pass the blocks and open the
 preview. The command loads the blocks into the Block Kit Builder in the
-developer's browser.
+user's browser.
 
 Because you run the CLI non-interactively, this command also needs a `--team` flag. Resolve the team ID with the `slack:slack-cli` skill, **Step 2: Command Discovery via Help**, whose "Resolving `--app` and `--team` values" guidance covers running `SLACK_CMD auth list`; Any authenticated workspace works for a preview, if several are available, pick one and mention which you used rather than blocking on the choice.
 
 **Path B: Block Kit Builder link (fallback, when Resolve Tooling recorded the CLI as unavailable).**
 
-Offer the Block Kit Builder link so the developer can paste the JSON in and tweak visually: `https://app.slack.com/block-kit-builder`. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
+Offer the Block Kit Builder link so the user can paste the JSON in and tweak visually: `https://app.slack.com/block-kit-builder`. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
 
 ---
 
 ## Step 7: Iterate
 
-Ask whether the developer wants to add, modify, remove, or reorder blocks, or build a layout for a different surface. If they want to change the layout you just produced, re-enter **Modification Mode** (it preserves their `block_id`/`action_id` values); for a fresh layout, loop back to Step 3.
+Ask whether the user wants to add, modify, remove, or reorder blocks, or build a layout for a different surface. If they want to change the layout you just produced, re-enter **Modification Mode** (it preserves their `block_id`/`action_id` values); for a fresh layout, loop back to Step 3.
 
 ---
 

--- a/tests/unit/test_block_kit_validation.py
+++ b/tests/unit/test_block_kit_validation.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+SKILL = Path("skills/block-kit/SKILL.md").read_text()
+
+
+def test_tooling_is_resolved_before_every_workflow_path() -> None:
+    resolve_tooling = SKILL.index("## Resolve Tooling")
+    fast_path = SKILL.index("## Fast Path")
+    modification_mode = SKILL.index("## Modification Mode")
+    validate = SKILL.index("## Step 5: Validate")
+    assert resolve_tooling < fast_path < modification_mode < validate
+    assert "`slack:slack-cli` skill, **Step 1: Detect the Slack CLI**" in SKILL
+    assert SKILL.count("**Step 1: Detect the Slack CLI**") == 1
+    assert "do not propose installation or ask about an alias" in SKILL
+    assert "Reuse the `SLACK_CMD` recorded in **Resolve Tooling**" in SKILL
+
+
+def test_cli_validation_contract_is_explicit() -> None:
+    assert "MUST attempt validation with the Slack CLI" in SKILL
+    assert "$SLACK_CMD api blocks.validate --no-auth 'blocks=[...]'" in SKILL
+    assert "$SLACK_CMD api blocks.validate --no-auth 'view={...}'" in SKILL
+    assert "attempt it directly without running `api --help`" in SKILL
+    assert 'validation response with `"ok": false`' in SKILL
+    assert "retry with the CLI rather than switching transports" in SKILL
+
+
+def test_permission_retry_does_not_bypass_host_policy() -> None:
+    assert "retry the identical command" in SKILL
+    assert "Never activate a permission bypass" in SKILL
+    assert "do not use another transport to evade that boundary" in SKILL
+
+
+def test_fallback_and_transport_are_disclosed() -> None:
+    assert "Retain the exact fallback reason for Step 6" in SKILL
+    assert "Validation transport: Slack CLI (<resolved command>)." in SKILL
+    assert "Validation transport: curl (Slack CLI unavailable: <reason>)." in SKILL
+    assert "Validation status: not validated" in SKILL
+    assert "Do not use\ncurl to hide payload errors" in SKILL

--- a/tests/unit/test_block_kit_validation.py
+++ b/tests/unit/test_block_kit_validation.py
@@ -1,6 +1,25 @@
+import re
 from pathlib import Path
 
 SKILL = Path("skills/block-kit/SKILL.md").read_text()
+PROSE = " ".join(SKILL.split())
+
+
+def test_all_requested_simplifications_remain_applied() -> None:
+    frontmatter = SKILL.split("---", 2)[1]
+    step_two = SKILL.split("## Step 2:", 1)[1].split("## Step 3:", 1)[0]
+    step_three = SKILL.split("## Step 3:", 1)[1].split("## Step 4:", 1)[0]
+    step_five_b = SKILL.split("### 5b. Handle the response", 1)[1].split(
+        "## Step 6:", 1
+    )[0]
+
+    assert "argument-hint:" not in frontmatter
+    assert "$0" not in SKILL
+    assert re.search(r"\bdevelopers?\b", SKILL, re.IGNORECASE) is None
+    assert "references/common-patterns.md" in step_two
+    assert '"A feedback form with a text input and a category selector"' not in step_two
+    assert "Surface constraints to check" not in step_three
+    assert "Explain the error" not in step_five_b
 
 
 def test_tooling_is_resolved_before_every_workflow_path() -> None:
@@ -11,7 +30,11 @@ def test_tooling_is_resolved_before_every_workflow_path() -> None:
     assert resolve_tooling < fast_path < modification_mode < validate
     assert "`slack:slack-cli` skill, **Step 1: Detect the Slack CLI**" in SKILL
     assert SKILL.count("**Step 1: Detect the Slack CLI**") == 1
-    assert "do not propose installation or ask about an alias" in SKILL
+    assert "alias inquiry/verification branch" in PROSE
+    assert "Do not propose installation unless the user independently asked" in PROSE
+    assert "installed under a different name or alias. If the user supplies an alias," in SKILL
+    assert "verify it with `<alias> _fingerprint 2>/dev/null` before setting `SLACK_CMD`." in SKILL
+    assert "If no alias is supplied or verified, record the CLI as unavailable and use" in SKILL
     assert "Reuse the `SLACK_CMD` recorded in **Resolve Tooling**" in SKILL
 
 
@@ -19,20 +42,50 @@ def test_cli_validation_contract_is_explicit() -> None:
     assert "MUST attempt validation with the Slack CLI" in SKILL
     assert "$SLACK_CMD api blocks.validate --no-auth 'blocks=[...]'" in SKILL
     assert "$SLACK_CMD api blocks.validate --no-auth 'view={...}'" in SKILL
-    assert "attempt it directly without running `api --help`" in SKILL
+    assert "attempt it directly without running `api --help`" in PROSE
     assert 'validation response with `"ok": false`' in SKILL
     assert "retry with the CLI rather than switching transports" in SKILL
+    assert "documented exception to that skill's generic help-first rule" in PROSE
 
 
 def test_permission_retry_does_not_bypass_host_policy() -> None:
     assert "retry the identical command" in SKILL
     assert "Never activate a permission bypass" in SKILL
     assert "do not use another transport to evade that boundary" in SKILL
+    assert (
+        "If permission is denied or unavailable, preserve the error, report"
+        ' that validation did not run, and stop' in PROSE
+    )
 
 
-def test_fallback_and_transport_are_disclosed() -> None:
-    assert "Retain the exact fallback reason for Step 6" in SKILL
+def test_cli_execution_failure_can_fall_back_with_precise_disclosure() -> None:
+    assert "the canonical CLI invocation cannot execute for a non-permission reason" in PROSE
+    assert "record its version and diagnostic help output, then use curl" in PROSE
+    assert "Retain the exact absence or execution-failure reason for Step 6" in PROSE
     assert "Validation transport: Slack CLI (<resolved command>)." in SKILL
     assert "Validation transport: curl (Slack CLI unavailable: <reason>)." in SKILL
+    assert "Validation transport: curl (Slack CLI execution failure: <reason>; version/help recorded)." in SKILL
     assert "Validation status: not validated" in SKILL
-    assert "Do not use\ncurl to hide payload errors" in SKILL
+    assert "Do not silently invent a different CLI invocation." in PROSE
+
+
+def test_semantic_payload_and_network_failures_stay_on_cli() -> None:
+    assert 'A parsed Slack semantic `"ok": false` response' in SKILL
+    assert "payload error" in SKILL
+    assert "network/service failure still counts as the CLI path executing" in PROSE
+    assert "rather than switching transports" in PROSE
+
+
+def test_absence_can_use_curl() -> None:
+    fallback = SKILL.split("**Path B: curl (fallback).**", 1)[1].split(
+        "### 5b. Handle the response", 1
+    )[0]
+    assert "resolved preflight state says the CLI is absent" in fallback
+
+
+def test_preview_and_iteration_reuse_the_simplified_user_facing_contract() -> None:
+    preview = SKILL.split("### Preview it", 1)[1].split("## Step 7:", 1)[0]
+    assert "Reuse the `SLACK_CMD` recorded in **Resolve Tooling**" in preview
+    assert "developer" not in preview.lower()
+    assert "user's browser" in preview
+    assert "Ask whether the user wants to add, modify, remove, or reorder blocks" in SKILL


### PR DESCRIPTION

### Summary

Closes #99.

- resolve the public Slack CLI once before any Block Kit workflow, including
  Fast Path and Modification Mode, including alias verification when the public
  CLI is installed under a different command name
- require the canonical no-auth CLI validation call when the CLI is available,
  keep semantic validation errors on that transport, and disclose the final
  validation transport precisely
- request narrowly scoped permission before an identical retry for CLI
  config/log write failures, and stop unvalidated when permission is denied
- allow curl only when the CLI is unavailable or the canonical CLI invocation
  itself cannot execute for a non-permission reason, with version/help captured
  for that execution-failure path
- remove the argument contract, developer-specific voice, duplicated pattern
  list, and redundant surface/error guidance identified in the issue

### Preview

This is a guidance-only change, so the preview is terminal evidence rather than
a product UI screenshot.

https://github.com/user-attachments/assets/480bbeac-4478-416d-a651-4c7cc4ae22fd

| Scenario | Prior supporting evidence | Exact local branch |
|---|---|---|
| installed CLI in Claude Code | `edb8e35` shows fingerprint followed immediately by the canonical validation call | same CLI-first state machine, plus alias verification and precise curl fallback only for genuine non-permission execution failure |
| semantic `ok:false` | payload corrected and retried on CLI | same transport-preserving retry contract |
| validation transport | CLI succeeded directly; zero curl | CLI when available, curl only when CLI is absent or the canonical invocation cannot execute; disclosure distinguishes those cases |

The attached recording is prior supporting evidence from local candidate
`edb8e35`; it is not an exact-head recording of this branch. It demonstrates
the CLI correction that this branch keeps while also folding in issue #99 items
1-5. These runs are not claims of official client support or live Slack API
execution.

### Testing

- `make lint`
- `make typecheck`
- `make test-unit` — 26/26 passed on exact head
- `claude plugin validate .`
- `PYTEST_ADDOPTS='-k skill-block-kit-modal' make test-eval` — the one
  change-relevant Block Kit tool-selection scenario passed
- `make test` — run on exact head: units passed 26/26 and evals passed 27/31
- Slack CLI v4.6.0 local checks: `slack api --help` documents `--no-auth`, and
  `slack api blocks.validate --no-auth 'blocks=[]'` returned `{"ok":true}`

The four exact-head full-suite failures were outside this PR's Block Kit diff:
two existing scenarios expect `slack_list_channel_members` although the current
hosted MCP endpoint did not return that tool, and two unrelated scenarios
received transient Gemini `503 UNAVAILABLE` responses. The changed Block Kit
evaluation passed.

For comparison, the same `make test` command on pristine `upstream/main`
`77a10794` under the same host and credentials passed 18/18 units and 22/31
evals. Its failures reproduced the same two deterministic upstream eval
problems, six transient Gemini `503 UNAVAILABLE` responses, and one model output
using `slack_docs` instead of the accepted `slack-docs` skill name. This
comparison shows the current branch introduces no demonstrated failure class;
it does not make the full command green.

### Notes

This changes only `skills/block-kit/SKILL.md`, one focused unit contract file,
and one patch changeset. It does not modify Slack CLI, MCP/OAuth, plugin
manifests, or official client-support documentation.

Open PR #85 still overlaps the old Step 2 inline inspiration list. The clean
resolution is to keep #85's three new templates in
`skills/block-kit/references/common-patterns.md` while this branch keeps Step 2
as a generic pointer to that file instead of an inline example list. A local
replay against `#85` head `dccb83e8` completed with one textual conflict in
`skills/block-kit/SKILL.md`; the clean resolution retained all three templates,
kept the generic pointer, and passed `make lint` plus `24/24` unit tests.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `make test` and the tests pass.

The last requirement remains unchecked because the exact required command was
run and still exits nonzero.
