### PR TITLE
docs: standardize skill descriptions to lead with triggers

### DIFF
--- a/.changeset/standardize-skill-descriptions.md
+++ b/.changeset/standardize-skill-descriptions.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Standardize every skill `description` to lead with its triggering conditions in consistent, impersonal phrasing, so the right skill loads more reliably for a given task. Documents the description convention in the maintainers guide and adds unit checks (length cap, trigger cue, impersonal voice) to keep future skills aligned.

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -48,6 +48,22 @@ source .venv/bin/activate
 
 ---
 
+## Authoring Skills
+
+A skill's `description` frontmatter is the only text an agent reads when deciding whether to load the skill, so write it deliberately. For general skill-authoring mechanics (structure, naming, frontmatter, testing), invoke the `superpowers:writing-skills` skill; if it isn't installed, its frontmatter rules follow the [Agent Skills specification][agent-skills].
+
+Every `description` in this repo follows these conventions:
+
+1. **Lead with the trigger, not the pitch.** Open with "Use when …" and describe the situation that should load the skill, not what it can do.
+2. **Don't summarize the workflow.** Listing what the skill covers is fine; a step-by-step of how it works is not, because an agent will follow the description instead of reading the skill body.
+3. **Write impersonally.** No first person ("I can …") or second person ("You can also …"). State the condition, not the assistant.
+4. **Pin the moment** with "before …" when the skill should fire at a specific point, e.g. before answering a question about Slack.
+5. **Pack in concrete keywords** an agent would match on: method names (`chat.postMessage`), error strings (`missing_scope`), MCP tool names (`slack_send_message`), CLI commands (`slack run`), and URL shapes (`slack.com/api/…`).
+6. **Name the Slack surface.** Say which part of Slack the trigger covers: Web API method, Block Kit modal, canvas, or channel search. Generic phrasing loses to a skill that names the surface.
+7. **Keep it to a line or two.** A fragment, no marketing adjectives. Aim under 500 characters; the hard cap is 1024.
+
+---
+
 ## Local Development & Testing
 
 Before you release (or open a PR), exercise your changes locally: run the test
@@ -239,6 +255,7 @@ Patch and minor updates are auto-approved and auto-merged via the
 
 ---
 
+[agent-skills]: https://agentskills.io/specification
 [claude-code]: https://claude.ai/code
 [cursor]: https://cursor.com
 [codex-cli]: https://developers.openai.com/codex/cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ When one `SKILL.md` references another skill (e.g., to delegate a step instead o
 
 See `skills/create-slack-app/SKILL.md` Step 1a for an example.
 
+## Skill descriptions
+
+A skill's `description` frontmatter is the only signal an agent uses to decide whether to load the skill. When adding or editing a skill, follow the repo's description conventions: lead with the trigger ("Use when …"), write impersonally, and pack in Slack-specific keywords. The full standard lives in the [maintainers guide](.github/maintainers_guide.md#authoring-skills). For general skill-authoring mechanics, invoke the `superpowers:writing-skills` skill.
+
 ## Testing
 
 Two test layers validate skills:

--- a/skills/block-kit/SKILL.md
+++ b/skills/block-kit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-kit
-description: 'Help developers build and validate Block Kit layouts for Slack messages, modals, and Home tabs. Provides authoritative block references and validates with the blocks.validate API. Use this skill whenever the developer wants to compose Slack message layouts, build modals/forms/dialogs, design Home tab interfaces, create interactive messages with buttons or menus, modify existing Block Kit JSON, or asks about any Slack UI component (sections, actions, inputs, headers, alerts, tables, carousels). Also trigger when they mention "blocks", "Block Kit Builder", want to preview or see the rendered version of blocks, or paste JSON containing block structures like `"type": "section"`.'
+description: 'Use when a developer wants to build or validate Block Kit layouts for Slack messages, modals, or Home tabs: message layouts, modals/forms/dialogs, Home tab interfaces, interactive buttons or menus, or modifying existing Block Kit JSON. Also trigger on any Slack UI component (sections, actions, inputs, headers, alerts, tables, carousels), the words "blocks" or "Block Kit Builder", a request to preview rendered blocks, or pasted JSON like "type": "section". Validates via the blocks.validate API method.'
 argument-hint: "[message | modal | home-tab]"
 ---
 

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-slack-app
-description: Guide developers through creating a Slack app or agent using the Slack CLI and Bolt (JS or Python). Handles prerequisites, sandbox setup, authentication, project creation from templates, and local development.
+description: 'Use when a developer wants to create, scaffold, or bootstrap a new Slack app or agent from scratch with the Slack CLI. Covers prerequisites, sandbox setup, authentication, and creating + running a project from a Bolt (JS or Python) template locally. Trigger on "create a Slack app", "new Bolt app", "start a Slack agent".'
 argument-hint: "[bolt-js | bolt-python]"
 ---
 

--- a/skills/slack-api/SKILL.md
+++ b/skills/slack-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-api
-description: "Discover, navigate, and call Slack Web API methods (the family.method endpoints at slack.com/api like chat.postMessage, conversations.history, users.info, views.open). Use this skill whenever the developer asks which Slack API method does something, needs a method's required OAuth scopes or token type, wants to call or test a Web API method, is handling cursor pagination (next_cursor), hitting rate limits (tier/ratelimited/Retry-After), or debugging API errors like missing_scope, invalid_auth, or channel_not_found. Also trigger when they paste a slack.com/api/ URL or a docs.slack.dev/reference/methods link, or ask how to list/fetch/post/update Slack resources via the API. This skill covers the Web API method layer: finding the right method, reading its contract (scopes, arguments, errors), and calling it over raw HTTP with curl or through a Slack SDK."
+description: "Use when a developer asks which Slack Web API method does something, needs a method's OAuth scopes or token type, wants to call or test a family.method endpoint (chat.postMessage, conversations.history, users.info, views.open), is handling cursor pagination (next_cursor) or rate limits (tier/ratelimited/Retry-After), or is debugging errors like missing_scope, invalid_auth, or channel_not_found. Also trigger on a pasted slack.com/api/ URL or docs.slack.dev/reference/methods link."
 argument-hint: "[method.name | family]"
 ---
 

--- a/skills/slack-cli/SKILL.md
+++ b/skills/slack-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-cli
-description: Use the Slack CLI to create, run, and manage Slack apps from the terminal. Use whenever the developer wants to log in, add a team, switch workspaces, or authenticate with Slack; whenever Slack CLI commands are needed (local development with `slack run`, managing app lifecycle, the manifest).
+description: "Use when a developer works with the Slack CLI (slack command) to create, run, or manage a Slack app from the terminal: logging in or authenticating (slack login), adding a team or switching workspaces, running locally (slack run), deploying, editing the app manifest, calling Web API methods (slack api), or searching Slack docs (slack docs search)."
 ---
 
 # Slack CLI

--- a/skills/slack-docs/SKILL.md
+++ b/skills/slack-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-docs
-description: "Search and read the official Slack platform documentation at docs.slack.dev. Use this skill to answer conceptual or how-to questions about Slack features. You can also use it to look up, fetch, or summarize specific guide pages from provided docs.slack.dev links."
+description: "Use when answering a conceptual or how-to question about Slack platform features, or when asked to look up, fetch, or summarize a docs.slack.dev page, including a pasted docs.slack.dev link. Covers finding and reading official Slack docs as clean markdown."
 argument-hint: "[topic or docs.slack.dev URL]"
 ---
 

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-messaging
-description: Compose and format effective Slack messages sent via the Slack MCP tools. Use whenever writing, drafting, scheduling, or improving a Slack message, announcement, or reply. Covers standard markdown formatting, message structure, thread etiquette, reactions, and scheduling, and points to the right dialect for canvases and Block Kit.
+description: "Use when writing, drafting, scheduling, or improving a Slack message, announcement, or reply sent via the Slack MCP tools (slack_send_message, slack_send_message_draft, slack_schedule_message). Covers Slack markdown formatting, message structure, thread etiquette, reactions, and scheduling, and points to the right dialect for canvases and Block Kit."
 ---
 
 # Slack Messaging Best Practices

--- a/skills/slack-search/SKILL.md
+++ b/skills/slack-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-search
-description: "Use when locating messages, files, channels, or people across Slack, or gathering context before answering, with the search MCP tools (slack_search_public, slack_search_public_and_private, slack_search_channels, slack_search_users). Covers search modifiers (in:, from:, before:), file-type filters, natural-language vs. keyword search, and reading results in context. Requires a Slack MCP Server connection."
+description: "Use when locating messages, files, channels, or people across Slack, or gathering context before answering, with the search MCP tools (slack_search_public, slack_search_public_and_private, slack_search_channels, slack_search_users). Covers search modifiers (in:, from:, before:), file-type filters, natural-language vs. keyword search, and reading results in context."
 ---
 
 # Slack Search

--- a/skills/slack-search/SKILL.md
+++ b/skills/slack-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-search
-description: Find messages, files, channels, and people across Slack with the search MCP tools. Use whenever locating conversations, gathering context before answering, or looking someone up. Covers search modifiers, file-type filters, natural-language vs. keyword search, and reading results in context.
+description: "Use when locating messages, files, channels, or people across Slack, or gathering context before answering, with the search MCP tools (slack_search_public, slack_search_public_and_private, slack_search_channels, slack_search_users). Covers search modifiers (in:, from:, before:), file-type filters, natural-language vs. keyword search, and reading results in context. Requires a Slack MCP Server connection."
 ---
 
 # Slack Search

--- a/tests/unit/test_frontmatter.py
+++ b/tests/unit/test_frontmatter.py
@@ -2,6 +2,20 @@ import re
 
 from tests.skill import discover_skills
 
+# Max skill `description` length; longer text is silently truncated (agentskills.io/specification).
+MAX_DESCRIPTION_LENGTH = 1024
+
+# Matches the trigger cue ("Use when", "whenever") a description should lead with.
+TRIGGER_CUE = re.compile(r"\bwhen(ever)?\b", re.IGNORECASE)
+
+# First-person voice; "I" needs a trailing contraction/verb (avoids "I/O", "Tier I"), and "us" is omitted ("US").
+FIRST_PERSON = re.compile(
+    r"\bI['’]"  # I'm, I'll, I've, I'd
+    r"|\bI\s+(?:am|can|will|would|have|had|do)\b"  # I am, I can, I will, ...
+    r"|\b(?:me|my|mine|myself|we|our|ours|ourselves)\b",
+    re.IGNORECASE,
+)
+
 
 def is_kebab_case(text: str) -> bool:
     # Pattern ensures lowercase alphanumeric chunks separated by a single dash
@@ -34,3 +48,26 @@ class TestFrontmatter:
     def test_skill_names_are_unique(self) -> None:
         names = [skill.frontmatter.name for skill in self.skills]
         assert len(names) == len(set(names)), f"Duplicate skill names found in: {sorted(names)}"
+
+    def test_description_length(self) -> None:
+        for skill in self.skills:
+            length = len(skill.frontmatter.description)
+            assert length <= MAX_DESCRIPTION_LENGTH, (
+                f"{skill.path} description is {length} characters, over the {MAX_DESCRIPTION_LENGTH}-character cap"
+            )
+
+    def test_description_leads_with_trigger_cue(self) -> None:
+        for skill in self.skills:
+            description = skill.frontmatter.description
+            assert TRIGGER_CUE.search(description), (
+                f"{skill.path} description should state when to use the skill "
+                f'(start with "Use when"); got: {description!r}'
+            )
+
+    def test_description_is_impersonal(self) -> None:
+        for skill in self.skills:
+            match = FIRST_PERSON.search(skill.frontmatter.description)
+            offending = match.group(0) if match else None
+            assert match is None, (
+                f"{skill.path} description uses first-person voice ({offending!r}); write it impersonally"
+            )


### PR DESCRIPTION
### Summary

This pull request standardizes every skill's `description` frontmatter so the right skill loads more reliably for a given task. Resolves #123.

- Rewrites all 7 skill descriptions to lead with a "Use when …" trigger, in impersonal voice, dropping workflow-summary phrasing while keeping their Slack-specific keywords.
- Documents the 7-point description convention in the maintainers guide, linked from `AGENTS.md`.
- Adds frontmatter unit checks: description length cap (≤ 1024), trigger cue, and impersonal voice.

### Preview

N/A — text and frontmatter changes only.

### Testing

- Skim the 7 rewritten descriptions and the new "Authoring Skills" section in the maintainers guide for accuracy.
- Local checks pass: `make lint`, `make typecheck`, and `make test-unit` (21/21, including the 3 new description checks). `make test-eval` was not run locally (needs a Gemini API key); CI runs it.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `make test` and the tests pass.
